### PR TITLE
feat: #64 AI 모델 확장을 고려한 AiProvider Enum 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 # CONTRIBUTING.md
 # manifest.json
 # openapi.yaml
+CLAUDE.md
 
 docker-compose.prod-monitoring.yml
 docker-compose.prod.yml

--- a/backend/src/main/java/com/back/backend/ai/client/AiProvider.java
+++ b/backend/src/main/java/com/back/backend/ai/client/AiProvider.java
@@ -1,0 +1,25 @@
+package com.back.backend.ai.client;
+
+import com.back.backend.global.jpa.converter.StringCodeEnum;
+
+/**
+ * AI 모델 제공자.
+ * 새 모델 추가 시 여기에 enum 값을 추가하고,
+ * 해당 provider의 AiClient 구현체를 만들면 됨
+ */
+public enum AiProvider implements StringCodeEnum {
+    GEMINI("gemini"),
+    OPENAI("openai"),
+    CLAUDE("claude");
+
+    private final String value;
+
+    AiProvider(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
## 🔗 Issue 번호

- Close #64 

## 🛠 작업 내역
- 글로벌 컨버터인 StringCodeEnum을 상속받아 DB 저장 및 API 통신 시 일관된 문자열 코드를 사용하도록 구성

- 새로운 AI 모델이 추가될 경우, 해당 Enum에 상수만 추가하고 구현체를 늘려가는 OCP(개방-폐쇄 원칙)를 지향할 수 있는 기반 마련

## ✅ 체크리스트

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?