### PR TITLE
feat:문서 삭제 시 물리 파일 삭제 연동

### DIFF
--- a/backend/src/main/java/com/back/backend/domain/document/service/DocumentService.java
+++ b/backend/src/main/java/com/back/backend/domain/document/service/DocumentService.java
@@ -186,5 +186,7 @@ public class DocumentService {
             );
         }
         documentRepository.delete(document);
+        // DB 삭제 후 물리 파일도 삭제 (실패 시 로그만 남기고 예외를 던지지 않음)
+        documentStorageService.delete(document.getStoragePath());
     }
 }

--- a/backend/src/main/java/com/back/backend/domain/document/storage/DocumentStorageService.java
+++ b/backend/src/main/java/com/back/backend/domain/document/storage/DocumentStorageService.java
@@ -20,4 +20,12 @@ public interface DocumentStorageService {
      * @return 저장된 파일의 경로 문자열 (DB의 {@code storage_path} 컬럼에 저장됨)
      */
     String store(MultipartFile file);
+
+    /**
+     * storagePath에 해당하는 물리 파일을 삭제한다.
+     * 파일이 존재하지 않으면 무시하고, 삭제 실패 시 로그만 남긴다.
+     *
+     * @param storagePath DB에 저장된 경로 문자열 (예: "uploads/uuid_filename.pdf")
+     */
+    void delete(String storagePath);
 }

--- a/backend/src/main/java/com/back/backend/domain/document/storage/LocalDocumentStorageService.java
+++ b/backend/src/main/java/com/back/backend/domain/document/storage/LocalDocumentStorageService.java
@@ -66,6 +66,31 @@ public class LocalDocumentStorageService implements DocumentStorageService {
     }
 
     /**
+     * storagePath에 해당하는 물리 파일을 삭제한다.
+     *
+     * <p>storagePath에서 파일명만 추출해 uploadDir 기준으로 resolve한다.
+     * 파일이 존재하지 않으면 무시하고, 삭제 실패 시 WARN 로그만 남긴다.
+     * DB 삭제가 이미 완료된 시점에서 호출되므로 예외를 던지지 않는다.</p>
+     */
+    @Override
+    public void delete(String storagePath) {
+        if (storagePath == null || storagePath.isBlank()) {
+            return;
+        }
+        try {
+            // storagePath 형식: "uploads/uuid_filename.pdf" → 파일명만 추출
+            String filename = Paths.get(storagePath).getFileName().toString();
+            Path filePath = uploadDir.resolve(filename);
+            boolean deleted = Files.deleteIfExists(filePath);
+            if (deleted) {
+                log.info("Physical file deleted: {}", filename);
+            }
+        } catch (IOException e) {
+            log.warn("Failed to delete physical file for storagePath={}: {}", storagePath, e.getMessage());
+        }
+    }
+
+    /**
      * 파일명에서 영문자, 숫자, ., _, - 외의 문자를 _로 치환한다.
      * null이거나 빈 값이면 "unnamed"를 반환한다.
      */

--- a/backend/src/test/java/com/back/backend/domain/document/service/DocumentServiceTest.java
+++ b/backend/src/test/java/com/back/backend/domain/document/service/DocumentServiceTest.java
@@ -210,7 +210,7 @@ class DocumentServiceTest {
     // --- deleteDocument ---
 
     @Test
-    void deleteDocument_deletesWhenNotInUse() {
+    void deleteDocument_deletesDbAndPhysicalFile() {
         User mockUser = user();
         Document doc = document(mockUser, DocumentType.RESUME, "resume.pdf");
         given(documentRepository.findByIdAndUserId(1L, 1L)).willReturn(Optional.of(doc));
@@ -219,6 +219,7 @@ class DocumentServiceTest {
         documentService.deleteDocument(1L, 1L);
 
         then(documentRepository).should().delete(doc);
+        then(documentStorageService).should().delete("uploads/resume.pdf");
     }
 
     @Test


### PR DESCRIPTION
   - DocumentStorageService: delete(storagePath) 메서드 추가
   - LocalDocumentStorageService: 파일 삭제 구현 (미존재 시 무시, 실패 시 WARN 로그)
   - DocumentService.deleteDocument(): DB 삭제 후 물리 파일 삭제 호출
   - DocumentServiceTest: 삭제 시 storage.delete() 호출 검증 추가

## 🔗 Issue 번호

- Close #

## 🛠 작업 내역

-

## ✅ 체크리스트

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?