### PR TITLE
fix: dockerfile의 하드코딩된 profile=prod를 변수로 빼서 profile=load-test넣을수 있도록 수정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -73,9 +73,10 @@ COPY --from=extractor /app/application/ ./
 EXPOSE 8080
 
 # Java 21 이상에서 효율이 좋은 ZGC 사용 및 메모리 최적화 옵션 적용
+ENV SPRING_PROFILES_ACTIVE=prod
+
 ENTRYPOINT ["java", \
   "-XX:+UseZGC", \
   "-XX:MaxRAMPercentage=75", \
   "-XX:InitialRAMPercentage=50", \
-  "-Dspring.profiles.active=prod", \
   "org.springframework.boot.loader.launch.JarLauncher"]


### PR DESCRIPTION
## 🔗 Issue 번호

- Close #

## 🛠 작업 내역
dockerfile 의 prod를 하드코딩해서 profile이 load-test로 바뀌지 않던 문제 수정
-

## ✅ 체크리스트

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?