### PR TITLE
Refactor: 문서 검색 기능을 LIKE 기반에서 PGroonga 전문 검색(FTS)으로 교체함

### DIFF
--- a/backend/src/main/java/com/back/backend/domain/document/controller/DocumentController.java
+++ b/backend/src/main/java/com/back/backend/domain/document/controller/DocumentController.java
@@ -60,6 +60,23 @@ public class DocumentController {
         return ApiResponse.success(documentService.getDocuments(userId));
     }
 
+    /**
+     * PGroonga 전문 검색(FTS)으로 문서를 검색한다.
+     *
+     * <p>extracted_text와 original_file_name 양쪽을 검색해 결과를 합산한다.
+     * &@~ 연산자를 사용하므로 PGroonga가 설치된 PostgreSQL 환경에서만 동작한다.</p>
+     *
+     * @param userId 인증된 사용자 ID
+     * @param query  검색 키워드 (최소 1자)
+     * @return 검색 결과 문서 목록 (관련도 내림차순, 최대 20개)
+     */
+    @GetMapping("/search")
+    public ApiResponse<List<DocumentResponse>> searchDocuments(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam("q") String query) {
+        return ApiResponse.success(documentService.search(userId, query));
+    }
+
     // 문서 단건 상세 조회 (200 OK / 404 Not Found)
     @GetMapping("/{documentId}")
     public ApiResponse<DocumentResponse> getDocument(

--- a/backend/src/main/java/com/back/backend/domain/document/repository/DocumentRepository.java
+++ b/backend/src/main/java/com/back/backend/domain/document/repository/DocumentRepository.java
@@ -4,6 +4,8 @@ package com.back.backend.domain.document.repository;
 import com.back.backend.domain.document.entity.Document;
 import com.back.backend.domain.document.entity.DocumentExtractStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,7 +30,7 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
 
     // 상세/삭제 조회: 문서 ID와 사용자 ID를 함께 확인해 다른 사용자 문서 접근을 막는다
     Optional<Document> findByIdAndUserId(Long id, Long userId);
-    
+
      // 지원 단위 생성 시 선택한 문서 ID 목록을 한 번에 조회한다
     // userId 조건으로 다른 사용자 문서를 연결하는 것을 방지한다
     // 호출 전 ids가 비어 있으면 빈 리스트를 반환해야 한다 (빈 IN절 방지)
@@ -37,4 +39,45 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
     // 준비 현황 대시보드: 특정 추출 상태인 문서 수 집계
     int countByUserIdAndExtractStatus(Long userId, DocumentExtractStatus extractStatus);
 
+    /**
+     * PGroonga를 사용해 추출된 텍스트에서 전문 검색(FTS)을 수행한다.
+     *
+     * <p>{@code &@~} 연산자: PGroonga의 전문 검색 연산자로 한국어/영어 형태소 분석 및
+     * Fuzzy search를 지원한다. PGroonga가 설치되지 않은 PostgreSQL에서는 오류가 발생한다.</p>
+     *
+     * <p>검색 결과는 PGroonga relevance score 내림차순으로 정렬되며,
+     * {@code extract_status = 'success'}인 문서만 반환한다.</p>
+     *
+     * @param userId 검색 대상 사용자 ID (다른 사용자 문서 접근 차단)
+     * @param query  검색 키워드 (한국어, 영어, Fuzzy 검색 지원)
+     * @return 검색 결과 문서 목록 (최대 20개, 관련도 내림차순)
+     */
+    @Query(value = """
+        SELECT * FROM documents
+        WHERE user_id = :userId
+          AND extract_status = 'success'
+          AND extracted_text &@~ :query
+        ORDER BY pgroonga_score(tableoid, ctid) DESC
+        LIMIT 20
+        """, nativeQuery = true)
+    List<Document> searchByText(@Param("userId") Long userId, @Param("query") String query);
+
+    /**
+     * PGroonga를 사용해 원본 파일명에서 전문 검색을 수행한다.
+     *
+     * <p>파일명 검색은 추출 상태와 무관하게 모든 문서에서 검색한다.
+     * 업로드 직후 PENDING 상태인 문서도 파일명으로 찾을 수 있도록 한다.</p>
+     *
+     * @param userId 검색 대상 사용자 ID
+     * @param query  검색 키워드
+     * @return 검색 결과 문서 목록 (최대 20개, 관련도 내림차순)
+     */
+    @Query(value = """
+        SELECT * FROM documents
+        WHERE user_id = :userId
+          AND original_file_name &@~ :query
+        ORDER BY pgroonga_score(tableoid, ctid) DESC
+        LIMIT 20
+        """, nativeQuery = true)
+    List<Document> searchByFileName(@Param("userId") Long userId, @Param("query") String query);
 }

--- a/backend/src/main/java/com/back/backend/domain/document/repository/DocumentRepository.java
+++ b/backend/src/main/java/com/back/backend/domain/document/repository/DocumentRepository.java
@@ -40,44 +40,30 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
     int countByUserIdAndExtractStatus(Long userId, DocumentExtractStatus extractStatus);
 
     /**
-     * PGroonga를 사용해 추출된 텍스트에서 전문 검색(FTS)을 수행한다.
+     * PGroonga 전문 검색(FTS) — extracted_text + original_file_name 통합 검색.
      *
-     * <p>{@code &@~} 연산자: PGroonga의 전문 검색 연산자로 한국어/영어 형태소 분석 및
-     * Fuzzy search를 지원한다. PGroonga가 설치되지 않은 PostgreSQL에서는 오류가 발생한다.</p>
+     * <p>{@code &@~} 연산자: PGroonga의 한국어/영어 형태소 분석 + Fuzzy search.
+     * 두 컬럼을 한 쿼리에서 OR로 검색하고, 컬럼별 score의 최댓값으로 정렬한다.</p>
      *
-     * <p>검색 결과는 PGroonga relevance score 내림차순으로 정렬되며,
-     * {@code extract_status = 'success'}인 문서만 반환한다.</p>
+     * <ul>
+     *   <li>extracted_text 매칭은 {@code extract_status = 'success'}인 문서로 제한.</li>
+     *   <li>original_file_name 매칭은 추출 상태와 무관(PENDING 문서도 파일명으로 검색 가능).</li>
+     *   <li>두 컬럼 모두 매칭되면 더 큰 score 기준으로 한 행만 반환.</li>
+     * </ul>
      *
      * @param userId 검색 대상 사용자 ID (다른 사용자 문서 접근 차단)
-     * @param query  검색 키워드 (한국어, 영어, Fuzzy 검색 지원)
-     * @return 검색 결과 문서 목록 (최대 20개, 관련도 내림차순)
-     */
-    @Query(value = """
-        SELECT * FROM documents
-        WHERE user_id = :userId
-          AND extract_status = 'success'
-          AND extracted_text &@~ :query
-        ORDER BY pgroonga_score(tableoid, ctid) DESC
-        LIMIT 20
-        """, nativeQuery = true)
-    List<Document> searchByText(@Param("userId") Long userId, @Param("query") String query);
-
-    /**
-     * PGroonga를 사용해 원본 파일명에서 전문 검색을 수행한다.
-     *
-     * <p>파일명 검색은 추출 상태와 무관하게 모든 문서에서 검색한다.
-     * 업로드 직후 PENDING 상태인 문서도 파일명으로 찾을 수 있도록 한다.</p>
-     *
-     * @param userId 검색 대상 사용자 ID
      * @param query  검색 키워드
      * @return 검색 결과 문서 목록 (최대 20개, 관련도 내림차순)
      */
     @Query(value = """
         SELECT * FROM documents
         WHERE user_id = :userId
-          AND original_file_name &@~ :query
+          AND (
+            (extract_status = 'success' AND extracted_text &@~ :query)
+            OR original_file_name &@~ :query
+          )
         ORDER BY pgroonga_score(tableoid, ctid) DESC
         LIMIT 20
         """, nativeQuery = true)
-    List<Document> searchByFileName(@Param("userId") Long userId, @Param("query") String query);
+    List<Document> search(@Param("userId") Long userId, @Param("query") String query);
 }

--- a/backend/src/main/java/com/back/backend/domain/document/service/DocumentService.java
+++ b/backend/src/main/java/com/back/backend/domain/document/service/DocumentService.java
@@ -202,6 +202,34 @@ public class DocumentService {
         documentStorageService.delete(document.getStoragePath());
     }
 
+    /**
+     * PGroonga 전문 검색(FTS)으로 문서를 검색한다.
+     *
+     * <p>extracted_text와 original_file_name 양쪽에서 검색해 결과를 합산(중복 제거)한다.
+     * PGroonga가 미설치된 환경에서는 repository가 예외를 던질 수 있다.</p>
+     *
+     * @param userId 검색 대상 사용자 ID
+     * @param query  검색 키워드 (한국어, 영어, Fuzzy 지원)
+     * @return 검색 결과 DTO 목록 (텍스트 우선, 파일명 추가, 중복 제거)
+     */
+    @Transactional(readOnly = true)
+    public List<DocumentResponse> search(Long userId, String query) {
+        List<Document> byText = documentRepository.searchByText(userId, query);
+        List<Document> byName = documentRepository.searchByFileName(userId, query);
+
+        // 텍스트 검색 결과 우선, 파일명 검색 결과 추가 — ID 기준 중복 제거
+        return java.util.stream.Stream.concat(byText.stream(), byName.stream())
+            .collect(java.util.stream.Collectors.toMap(
+                Document::getId,
+                d -> d,
+                (a, b) -> a,            // 중복 시 먼저 나온 것 유지
+                java.util.LinkedHashMap::new
+            ))
+            .values().stream()
+            .map(DocumentResponse::from)
+            .toList();
+    }
+
     // 추출된 텍스트를 업데이트한다. 사용자만 자신의 문서를 수정할 수 있다.
     @Transactional
     public DocumentResponse updateExtractedText(Long userId, Long documentId, String extractedText) {

--- a/backend/src/main/java/com/back/backend/domain/document/service/DocumentService.java
+++ b/backend/src/main/java/com/back/backend/domain/document/service/DocumentService.java
@@ -205,27 +205,17 @@ public class DocumentService {
     /**
      * PGroonga 전문 검색(FTS)으로 문서를 검색한다.
      *
-     * <p>extracted_text와 original_file_name 양쪽에서 검색해 결과를 합산(중복 제거)한다.
+     * <p>extracted_text(success 상태 한정)와 original_file_name 양쪽을 단일 쿼리로 OR 검색하고
+     * PGroonga relevance score 내림차순으로 정렬한다.
      * PGroonga가 미설치된 환경에서는 repository가 예외를 던질 수 있다.</p>
      *
      * @param userId 검색 대상 사용자 ID
      * @param query  검색 키워드 (한국어, 영어, Fuzzy 지원)
-     * @return 검색 결과 DTO 목록 (텍스트 우선, 파일명 추가, 중복 제거)
+     * @return 검색 결과 DTO 목록 (관련도 내림차순, 최대 20개)
      */
     @Transactional(readOnly = true)
     public List<DocumentResponse> search(Long userId, String query) {
-        List<Document> byText = documentRepository.searchByText(userId, query);
-        List<Document> byName = documentRepository.searchByFileName(userId, query);
-
-        // 텍스트 검색 결과 우선, 파일명 검색 결과 추가 — ID 기준 중복 제거
-        return java.util.stream.Stream.concat(byText.stream(), byName.stream())
-            .collect(java.util.stream.Collectors.toMap(
-                Document::getId,
-                d -> d,
-                (a, b) -> a,            // 중복 시 먼저 나온 것 유지
-                java.util.LinkedHashMap::new
-            ))
-            .values().stream()
+        return documentRepository.search(userId, query).stream()
             .map(DocumentResponse::from)
             .toList();
     }

--- a/backend/src/main/resources/db/migration/V19__add_pgroonga_search.sql
+++ b/backend/src/main/resources/db/migration/V19__add_pgroonga_search.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- V19: PGroonga 전문 검색(FTS) 인덱스 추가
+--
+-- PGroonga는 PostgreSQL용 고성능 전문 검색 확장이다.
+-- &@~ 연산자로 Fuzzy search / FTS / 한국어 형태소 분석을 지원한다.
+--
+-- 환경별 동작:
+--   - PGroonga 설치된 환경(Docker: groonga/pgroonga:*): 확장 및 인덱스 생성
+--   - 일반 PostgreSQL(로컬 개발, 기존 CI): 경고만 출력하고 마이그레이션 통과
+--     → searchByText/searchByFileName API는 이 환경에서 오류를 반환할 수 있음
+-- ============================================================
+
+DO $$
+BEGIN
+    CREATE EXTENSION IF NOT EXISTS pgroonga;
+    RAISE NOTICE 'PGroonga extension created/already exists.';
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE WARNING 'PGroonga extension not available: %. FTS indexes will not be created.', SQLERRM;
+END $$;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pgroonga') THEN
+        -- extracted_text 전문 검색 인덱스
+        -- pgroonga_text_full_text_search_ops_v2: 한국어/영어 FTS + Fuzzy search 지원
+        EXECUTE 'CREATE INDEX IF NOT EXISTS pgroonga_documents_extracted_text
+                 ON documents USING pgroonga (extracted_text pgroonga_text_full_text_search_ops_v2)';
+
+        -- 파일명 검색 인덱스
+        EXECUTE 'CREATE INDEX IF NOT EXISTS pgroonga_documents_filename
+                 ON documents USING pgroonga (original_file_name pgroonga_text_full_text_search_ops_v2)';
+
+        RAISE NOTICE 'PGroonga FTS indexes created on documents table.';
+    ELSE
+        RAISE WARNING 'PGroonga not enabled. Run with groonga/pgroonga image for FTS support.';
+    END IF;
+END $$;

--- a/backend/src/test/java/com/back/backend/config/PGroongaTestcontainersConfiguration.java
+++ b/backend/src/test/java/com/back/backend/config/PGroongaTestcontainersConfiguration.java
@@ -18,14 +18,15 @@ import java.util.Map;
  * 검색 관련 통합 테스트 전용으로 분리한다.</p>
  *
  * <h3>사용법</h3>
- * <pre>
- * {@literal @}SpringBootTest
- * {@literal @}ActiveProfiles("test")
- * {@literal @}Import(PGroongaTestcontainersConfiguration.class)
- * class DocumentSearchRepositoryTest { ... }
- * </pre>
+ * <p>{@link com.back.backend.support.PGroongaIntegrationTest} 메타 어노테이션을 클래스에 붙이면
+ * 이 설정이 자동으로 적용된다.</p>
  *
- * <p>Redis 컨테이너는 {@link TestcontainersConfiguration}과 동일하게 구성한다.</p>
+ * <h3>이미지 핀 정책</h3>
+ * <p>{@code latest} 태그 대신 SHA256 digest로 핀하여 CI에서 예기치 않은 이미지 변경을 방지한다.
+ * 업그레이드 시 digest를 명시적으로 갱신한다.</p>
+ *
+ * <p>Redis 빈은 {@link TestcontainersConfiguration}과 공유하지 않고 독립 선언한다.
+ * Spring 컨텍스트가 분리되어 있으므로 두 설정을 동시에 import하면 빈 충돌이 발생한다.</p>
  */
 @TestConfiguration(proxyBeanMethods = false)
 public class PGroongaTestcontainersConfiguration {
@@ -33,14 +34,15 @@ public class PGroongaTestcontainersConfiguration {
     /**
      * PGroonga 확장이 설치된 PostgreSQL 16 컨테이너.
      *
-     * <p>{@code asCompatibleSubstituteFor("postgres")}로 Testcontainers의
-     * PostgreSQL 드라이버 자동 감지가 동작하도록 선언한다.</p>
+     * <p>digest 핀: {@code groonga/pgroonga:latest-alpine-16@sha256:630426f963bb120aa15dac3cfffcfeb249c2b9b5db534be611b4aebfe3983d85}
+     * (2026-04-08 기준. 업그레이드 시 {@code docker pull groonga/pgroonga:latest-alpine-16}로 새 digest 확인 후 갱신)</p>
      */
     @Bean
     @ServiceConnection
     PostgreSQLContainer<?> postgresContainer() {
         return new PostgreSQLContainer<>(
-            DockerImageName.parse("groonga/pgroonga:latest-alpine-16")
+            DockerImageName.parse(
+                "groonga/pgroonga@sha256:630426f963bb120aa15dac3cfffcfeb249c2b9b5db534be611b4aebfe3983d85")
                 .asCompatibleSubstituteFor("postgres"))
             .withTmpFs(Map.of("/var/lib/postgresql/data", "rw"))
             .withCommand("postgres -c max_connections=300")

--- a/backend/src/test/java/com/back/backend/config/PGroongaTestcontainersConfiguration.java
+++ b/backend/src/test/java/com/back/backend/config/PGroongaTestcontainersConfiguration.java
@@ -1,0 +1,58 @@
+package com.back.backend.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+
+/**
+ * PGroonga 전문 검색 통합 테스트용 Testcontainers 설정.
+ *
+ * <p>일반 {@link TestcontainersConfiguration}(postgres:16-alpine) 대신
+ * PGroonga가 사전 설치된 PostgreSQL 이미지를 사용한다.
+ * PGroonga 없이는 {@code &@~} 연산자와 FTS 인덱스가 동작하지 않으므로
+ * 검색 관련 통합 테스트 전용으로 분리한다.</p>
+ *
+ * <h3>사용법</h3>
+ * <pre>
+ * {@literal @}SpringBootTest
+ * {@literal @}ActiveProfiles("test")
+ * {@literal @}Import(PGroongaTestcontainersConfiguration.class)
+ * class DocumentSearchRepositoryTest { ... }
+ * </pre>
+ *
+ * <p>Redis 컨테이너는 {@link TestcontainersConfiguration}과 동일하게 구성한다.</p>
+ */
+@TestConfiguration(proxyBeanMethods = false)
+public class PGroongaTestcontainersConfiguration {
+
+    /**
+     * PGroonga 확장이 설치된 PostgreSQL 16 컨테이너.
+     *
+     * <p>{@code asCompatibleSubstituteFor("postgres")}로 Testcontainers의
+     * PostgreSQL 드라이버 자동 감지가 동작하도록 선언한다.</p>
+     */
+    @Bean
+    @ServiceConnection
+    PostgreSQLContainer<?> postgresContainer() {
+        return new PostgreSQLContainer<>(
+            DockerImageName.parse("groonga/pgroonga:latest-alpine-16")
+                .asCompatibleSubstituteFor("postgres"))
+            .withTmpFs(Map.of("/var/lib/postgresql/data", "rw"))
+            .withCommand("postgres -c max_connections=300")
+            .withReuse(true);
+    }
+
+    @Bean
+    @ServiceConnection(name = "redis")
+    GenericContainer<?> redisContainer() {
+        return new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withTmpFs(Map.of("/data", "rw"))
+            .withExposedPorts(6379)
+            .withReuse(true);
+    }
+}

--- a/backend/src/test/java/com/back/backend/domain/document/controller/DocumentApiTest.java
+++ b/backend/src/test/java/com/back/backend/domain/document/controller/DocumentApiTest.java
@@ -296,6 +296,51 @@ class DocumentApiTest extends ApiTestBase {
     }
 
     // =========================================================
+    // GET /api/v1/documents/search
+    // =========================================================
+
+    @Test
+    void searchDocuments_returns401WhenUnauthenticated() throws Exception {
+        mockMvc.perform(get("/api/v1/documents/search").param("q", "Spring Boot"))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value(ErrorCode.AUTH_REQUIRED.name()));
+    }
+
+    @Test
+    void searchDocuments_returns200WithMatchingResults() throws Exception {
+        DocumentResponse doc = new DocumentResponse(
+            1L, DocumentType.RESUME.getValue(), "이력서.pdf",
+            "application/pdf", 2048L,
+            DocumentExtractStatus.SUCCESS.getValue(),
+            Instant.parse("2026-01-01T00:00:00Z"),
+            Instant.parse("2026-01-01T00:00:02Z"),
+            "Spring Boot 백엔드 개발자"
+        );
+        given(documentService.search(eq(1L), eq("Spring Boot"))).willReturn(List.of(doc));
+
+        mockMvc.perform(get("/api/v1/documents/search")
+                .param("q", "Spring Boot")
+                .with(authenticated(1L)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.length()").value(1))
+            .andExpect(jsonPath("$.data[0].originalFileName").value("이력서.pdf"));
+    }
+
+    @Test
+    void searchDocuments_returns200WithEmptyResultWhenNoMatch() throws Exception {
+        given(documentService.search(any(), any())).willReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/documents/search")
+                .param("q", "Python")
+                .with(authenticated(1L)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    // =========================================================
     // Test helpers
     // =========================================================
 

--- a/backend/src/test/java/com/back/backend/domain/document/repository/DocumentSearchRepositoryTest.java
+++ b/backend/src/test/java/com/back/backend/domain/document/repository/DocumentSearchRepositoryTest.java
@@ -59,7 +59,7 @@ class DocumentSearchRepositoryTest {
         persistDocument(user, "이력서.pdf", "Java Spring Boot 백엔드 개발자입니다. MSA 경험 3년.");
         em.flush();
 
-        List<Document> results = documentRepository.searchByText(user.getId(), "Spring Boot");
+        List<Document> results = documentRepository.search(user.getId(), "Spring Boot");
 
         assertThat(results).hasSize(1);
         assertThat(results.get(0).getOriginalFileName()).isEqualTo("이력서.pdf");
@@ -70,7 +70,7 @@ class DocumentSearchRepositoryTest {
         persistDocument(user, "이력서.pdf", "Java 백엔드 개발자.");
         em.flush();
 
-        List<Document> results = documentRepository.searchByText(user.getId(), "Python");
+        List<Document> results = documentRepository.search(user.getId(), "Python");
 
         assertThat(results).isEmpty();
     }
@@ -82,7 +82,7 @@ class DocumentSearchRepositoryTest {
         persistDocument(user, "내이력서.pdf", "Java 개발자");
         em.flush();
 
-        List<Document> results = documentRepository.searchByText(user.getId(), "Spring Boot");
+        List<Document> results = documentRepository.search(user.getId(), "Spring Boot");
 
         assertThat(results).isEmpty();
     }
@@ -103,7 +103,7 @@ class DocumentSearchRepositoryTest {
         em.persist(doc);
         em.flush();
 
-        List<Document> results = documentRepository.searchByText(user.getId(), "Spring Boot");
+        List<Document> results = documentRepository.search(user.getId(), "Spring Boot");
 
         assertThat(results).isEmpty();
     }
@@ -113,7 +113,7 @@ class DocumentSearchRepositoryTest {
         persistDocument(user, "이력서.pdf", "백엔드 개발자 포트폴리오. Spring Boot, JPA, Redis 활용.");
         em.flush();
 
-        List<Document> results = documentRepository.searchByText(user.getId(), "백엔드");
+        List<Document> results = documentRepository.search(user.getId(), "백엔드");
 
         assertThat(results).hasSize(1);
     }
@@ -128,7 +128,7 @@ class DocumentSearchRepositoryTest {
         persistDocument(user, "portfolio_design.pdf", "포트폴리오 내용");
         em.flush();
 
-        List<Document> results = documentRepository.searchByFileName(user.getId(), "resume");
+        List<Document> results = documentRepository.search(user.getId(), "resume");
 
         assertThat(results).hasSize(1);
         assertThat(results.get(0).getOriginalFileName()).isEqualTo("resume_2026.pdf");
@@ -139,7 +139,7 @@ class DocumentSearchRepositoryTest {
         persistDocument(otherUser, "resume.pdf", "내용");
         em.flush();
 
-        List<Document> results = documentRepository.searchByFileName(user.getId(), "resume");
+        List<Document> results = documentRepository.search(user.getId(), "resume");
 
         assertThat(results).isEmpty();
     }

--- a/backend/src/test/java/com/back/backend/domain/document/repository/DocumentSearchRepositoryTest.java
+++ b/backend/src/test/java/com/back/backend/domain/document/repository/DocumentSearchRepositoryTest.java
@@ -1,18 +1,15 @@
 package com.back.backend.domain.document.repository;
 
-import com.back.backend.config.PGroongaTestcontainersConfiguration;
 import com.back.backend.domain.document.entity.Document;
 import com.back.backend.domain.document.entity.DocumentExtractStatus;
 import com.back.backend.domain.document.entity.DocumentType;
 import com.back.backend.domain.user.entity.User;
 import com.back.backend.domain.user.entity.UserStatus;
+import com.back.backend.support.PGroongaIntegrationTest;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
@@ -23,15 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * PGroonga 전문 검색(FTS) 통합 테스트.
  *
- * <p>PGroonga가 설치된 PostgreSQL 컨테이너({@link PGroongaTestcontainersConfiguration})를 사용해
+ * <p>{@link PGroongaIntegrationTest}로 PGroonga 설치 PostgreSQL 컨테이너를 자동 구성한다.
  * {@code &@~} 연산자 기반 검색이 실제로 동작하는지 검증한다.</p>
- *
- * <p>일반 {@code @IntegrationTest}와 달리 PGroonga 이미지를 사용하므로
- * Docker Hub에서 이미지를 처음 pull하는 경우 시간이 걸릴 수 있다.</p>
  */
-@SpringBootTest
-@ActiveProfiles("test")
-@Import(PGroongaTestcontainersConfiguration.class)
+@PGroongaIntegrationTest
 @Transactional
 class DocumentSearchRepositoryTest {
 

--- a/backend/src/test/java/com/back/backend/domain/document/repository/DocumentSearchRepositoryTest.java
+++ b/backend/src/test/java/com/back/backend/domain/document/repository/DocumentSearchRepositoryTest.java
@@ -1,0 +1,176 @@
+package com.back.backend.domain.document.repository;
+
+import com.back.backend.config.PGroongaTestcontainersConfiguration;
+import com.back.backend.domain.document.entity.Document;
+import com.back.backend.domain.document.entity.DocumentExtractStatus;
+import com.back.backend.domain.document.entity.DocumentType;
+import com.back.backend.domain.user.entity.User;
+import com.back.backend.domain.user.entity.UserStatus;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * PGroonga 전문 검색(FTS) 통합 테스트.
+ *
+ * <p>PGroonga가 설치된 PostgreSQL 컨테이너({@link PGroongaTestcontainersConfiguration})를 사용해
+ * {@code &@~} 연산자 기반 검색이 실제로 동작하는지 검증한다.</p>
+ *
+ * <p>일반 {@code @IntegrationTest}와 달리 PGroonga 이미지를 사용하므로
+ * Docker Hub에서 이미지를 처음 pull하는 경우 시간이 걸릴 수 있다.</p>
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(PGroongaTestcontainersConfiguration.class)
+@Transactional
+class DocumentSearchRepositoryTest {
+
+    @Autowired
+    private DocumentRepository documentRepository;
+
+    @Autowired
+    private EntityManager em;
+
+    private User user;
+    private User otherUser;
+
+    @BeforeEach
+    void setUp() {
+        user = persistUser("searcher@example.com");
+        otherUser = persistUser("other@example.com");
+    }
+
+    // =========================================================
+    // 텍스트 검색 (extractedText 기준)
+    // =========================================================
+
+    @Test
+    void searchByText_returnsMatchingDocument() {
+        persistDocument(user, "이력서.pdf", "Java Spring Boot 백엔드 개발자입니다. MSA 경험 3년.");
+        em.flush();
+
+        List<Document> results = documentRepository.searchByText(user.getId(), "Spring Boot");
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getOriginalFileName()).isEqualTo("이력서.pdf");
+    }
+
+    @Test
+    void searchByText_returnsEmptyWhenNoMatch() {
+        persistDocument(user, "이력서.pdf", "Java 백엔드 개발자.");
+        em.flush();
+
+        List<Document> results = documentRepository.searchByText(user.getId(), "Python");
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void searchByText_doesNotReturnOtherUsersDocuments() {
+        // 다른 사용자의 문서에 검색어가 포함되어 있어도 반환하지 않는다
+        persistDocument(otherUser, "타인이력서.pdf", "Spring Boot 전문가");
+        persistDocument(user, "내이력서.pdf", "Java 개발자");
+        em.flush();
+
+        List<Document> results = documentRepository.searchByText(user.getId(), "Spring Boot");
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void searchByText_returnsOnlySuccessStatusDocuments() {
+        // PENDING 상태 문서는 검색에서 제외
+        Document doc = Document.builder()
+            .user(user)
+            .documentType(DocumentType.RESUME)
+            .originalFileName("pending.pdf")
+            .storagePath("uploads/pending.pdf")
+            .mimeType("application/pdf")
+            .fileSizeBytes(1024L)
+            .extractStatus(DocumentExtractStatus.PENDING) // ← PENDING, extractedText null
+            .uploadedAt(Instant.now())
+            .build();
+        em.persist(doc);
+        em.flush();
+
+        List<Document> results = documentRepository.searchByText(user.getId(), "Spring Boot");
+
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void searchByText_handlesKoreanQuery() {
+        persistDocument(user, "이력서.pdf", "백엔드 개발자 포트폴리오. Spring Boot, JPA, Redis 활용.");
+        em.flush();
+
+        List<Document> results = documentRepository.searchByText(user.getId(), "백엔드");
+
+        assertThat(results).hasSize(1);
+    }
+
+    // =========================================================
+    // 파일명 검색 (originalFileName 기준)
+    // =========================================================
+
+    @Test
+    void searchByFileName_returnsMatchingDocument() {
+        persistDocument(user, "resume_2026.pdf", "경력기술서 내용");
+        persistDocument(user, "portfolio_design.pdf", "포트폴리오 내용");
+        em.flush();
+
+        List<Document> results = documentRepository.searchByFileName(user.getId(), "resume");
+
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getOriginalFileName()).isEqualTo("resume_2026.pdf");
+    }
+
+    @Test
+    void searchByFileName_doesNotReturnOtherUsersDocuments() {
+        persistDocument(otherUser, "resume.pdf", "내용");
+        em.flush();
+
+        List<Document> results = documentRepository.searchByFileName(user.getId(), "resume");
+
+        assertThat(results).isEmpty();
+    }
+
+    // =========================================================
+    // Test helpers
+    // =========================================================
+
+    private User persistUser(String email) {
+        User u = User.builder()
+            .email(email)
+            .displayName("tester")
+            .status(UserStatus.ACTIVE)
+            .build();
+        em.persist(u);
+        return u;
+    }
+
+    private Document persistDocument(User owner, String fileName, String extractedText) {
+        Document doc = Document.builder()
+            .user(owner)
+            .documentType(DocumentType.RESUME)
+            .originalFileName(fileName)
+            .storagePath("uploads/" + fileName)
+            .mimeType("application/pdf")
+            .fileSizeBytes(1024L)
+            .extractStatus(DocumentExtractStatus.SUCCESS)
+            .uploadedAt(Instant.now())
+            .build();
+        doc.markExtracted(extractedText, Instant.now());
+        em.persist(doc);
+        return doc;
+    }
+}

--- a/backend/src/test/java/com/back/backend/support/PGroongaIntegrationTest.java
+++ b/backend/src/test/java/com/back/backend/support/PGroongaIntegrationTest.java
@@ -1,0 +1,36 @@
+package com.back.backend.support;
+
+import com.back.backend.config.PGroongaTestcontainersConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * PGroonga 전문 검색 통합 테스트용 메타 어노테이션.
+ *
+ * <p>SpringBootTest + test 프로파일 + PGroonga 설치 PostgreSQL Testcontainer를 한 번에 적용한다.
+ * 일반 통합 테스트({@link IntegrationTest})와 달리 {@code groonga/pgroonga} 이미지를 사용하므로
+ * {@code &@~} 연산자 기반 FTS가 실제로 동작한다.</p>
+ *
+ * <ul>
+ *   <li><b>로컬에서 Docker Desktop이 실행 중이어야 한다.</b>
+ *       처음 실행 시 PGroonga 이미지 pull 시간이 걸릴 수 있다.</li>
+ *   <li><b>일반 {@code @IntegrationTest}와 컨텍스트를 공유하지 않는다.</b>
+ *       PostgreSQL 이미지가 다르므로 별도 Spring 컨텍스트가 뜬다.
+ *       PGroonga 테스트 클래스끼리는 컨텍스트를 재사용한다.</li>
+ *   <li><b>순수 단위 테스트에는 사용하지 말 것.</b>
+ *       {@code @ExtendWith(MockitoExtension.class)}로 충분한 경우 이 어노테이션이 불필요하다.</li>
+ * </ul>
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@SpringBootTest
+@ActiveProfiles("test")
+@Import(PGroongaTestcontainersConfiguration.class)
+public @interface PGroongaIntegrationTest {
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,7 @@ services:
     restart: always
 
   db:
-    # PGroonga 전문 검색(FTS) 지원을 위해 groonga/pgroonga 이미지 사용.
-    # PGroonga는 &@~ 연산자로 한국어/영어 FTS + Fuzzy search를 지원한다.
-    # 이전: postgres:15-alpine → 이후: groonga/pgroonga:latest-alpine-15
+    # 이전: postgres:15-alpine → 이후: groonga/pgroonga:latest-alpine-15 (PGroonga 전문 검색(FTS) 지원 위해 변경
     image: groonga/pgroonga:latest-alpine-15
     container_name: local-db
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,10 @@ services:
     restart: always
 
   db:
-    image: postgres:15-alpine
+    # PGroonga 전문 검색(FTS) 지원을 위해 groonga/pgroonga 이미지 사용.
+    # PGroonga는 &@~ 연산자로 한국어/영어 FTS + Fuzzy search를 지원한다.
+    # 이전: postgres:15-alpine → 이후: groonga/pgroonga:latest-alpine-15
+    image: groonga/pgroonga:latest-alpine-15
     container_name: local-db
     environment:
       POSTGRES_USER: user

--- a/docs/document-domain-changes.md
+++ b/docs/document-domain-changes.md
@@ -1,0 +1,67 @@
+# Document Domain Changes Log
+
+이 문서는 Document 도메인 개선 작업의 변경 이력과 설계 결정을 기록한다.
+
+---
+
+## Feature 3: PGroonga 전문 검색 (`feat/document-pgroonga-search`)
+
+**목적**: 단순 LIKE 검색 대신 PGroonga `&@~` 연산자로 한국어/영어 FTS + Fuzzy search 지원.
+
+### 변경 내용
+
+| 파일 | 변경 유형 | 설명 |
+|------|----------|------|
+| `docker-compose.yml` | 수정 | `postgres:15-alpine` → `groonga/pgroonga:latest-alpine-15` |
+| `V19__add_pgroonga_search.sql` | 신규 | PGroonga 확장 생성 + FTS 인덱스 (fail-safe) |
+| `DocumentRepository.java` | 수정 | `searchByText`, `searchByFileName` 네이티브 쿼리 추가 |
+| `DocumentService.java` | 수정 | `search()` 메서드 추가 (텍스트 + 파일명 검색 합산) |
+| `DocumentController.java` | 수정 | `GET /api/v1/documents/search?q=` 엔드포인트 추가 |
+| `openapi.yaml` | 수정 | `/documents/search` 엔드포인트 명세 추가 |
+| `PGroongaTestcontainersConfiguration.java` | 신규 | PGroonga Docker 이미지 사용 TC 설정 |
+| `DocumentSearchRepositoryTest.java` | 신규 | PGroonga FTS 통합 테스트 (7개) |
+| `DocumentApiTest.java` | 수정 | 검색 API 테스트 3개 추가 (19개 → 22개) |
+
+### 설계 결정
+
+- **fail-safe 마이그레이션**: V19 마이그레이션은 `DO $$ EXCEPTION`으로 감싸 PGroonga 미설치 환경에서도 Flyway가 통과한다. 다만 `&@~` 연산자는 PGroonga 없이는 쿼리 실패한다.
+- **분리된 TC 설정**: 일반 통합 테스트(`postgres:16-alpine`)와 PGroonga 테스트(`groonga/pgroonga:latest-alpine-16`)를 TC 설정으로 분리해 기존 테스트에 영향 없음.
+- **검색 합산**: `searchByText` + `searchByFileName` 결과를 LinkedHashMap으로 합산해 중복 제거. 텍스트 검색 결과가 우선.
+- **결과 제한**: 최대 20개, `pgroonga_score` 내림차순 — 관련도 높은 문서가 먼저 노출.
+
+### API 명세
+
+```
+GET /api/v1/documents/search?q={keyword}
+Authorization: Cookie JWT 필요
+Response: ApiResponse<List<DocumentResponse>>
+```
+
+### 환경 요구사항
+
+**로컬 개발**: `docker-compose.yml`이 `groonga/pgroonga:latest-alpine-15`를 사용하므로 `docker-compose up db` 시 PGroonga 사용 가능.
+
+**테스트**: `DocumentSearchRepositoryTest`는 `groonga/pgroonga:latest-alpine-16` TC 이미지를 자동으로 Pull해 사용.
+
+### 테스트
+
+- `DocumentSearchRepositoryTest`: PGroonga TC 이미지 기반 실제 FTS 동작 검증 (7개)
+  - 키워드로 extractedText 검색
+  - 결과 없음 처리
+  - 다른 사용자 문서 접근 차단
+  - PENDING 문서 검색 제외
+  - 한국어 키워드 검색
+  - 파일명 검색
+- `DocumentApiTest`: 검색 API HTTP 레이어 검증 3개 추가
+
+---
+
+## Feature 2: 업로드 처리 시간 단축 (`perf/document-upload-bottleneck`)
+
+> 별도 브랜치 `perf/document-upload-bottleneck` 참고.
+
+---
+
+## Feature 1: PDF OCR 지원 (`feat/document-pdf-ocr`)
+
+> 별도 브랜치 `feat/document-pdf-ocr` 참고.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2348,6 +2348,48 @@ paths:
                       extractedAt: '2026-03-17T10:31:12Z'
                       extractedText: Spring Boot 기반 프로젝트 경험 ...
                     meta: *id002
+  /documents/search:
+    get:
+      tags:
+      - Documents
+      summary: 문서 전문 검색 (PGroonga FTS)
+      description: |
+        PGroonga의 `&@~` 연산자를 사용해 extracted_text와 original_file_name에서 전문 검색을 수행한다.
+        한국어/영어 형태소 분석 및 Fuzzy search를 지원한다.
+
+        **요구사항**: PGroonga 확장이 설치된 PostgreSQL 환경(운영 서버)에서만 정상 동작한다.
+      security:
+        - cookieAuth: []
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: 검색 키워드 (한국어, 영어, Fuzzy 검색 지원)
+          schema:
+            type: string
+            minLength: 1
+            example: "Spring Boot"
+      responses:
+        '200':
+          description: 검색 성공 (결과 없을 시 빈 배열 반환)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DocumentListResponse'
+              example:
+                success: true
+                data:
+                  - id: 1
+                    documentType: resume
+                    originalFileName: 이력서_2026.pdf
+                    mimeType: application/pdf
+                    fileSizeBytes: 153600
+                    extractStatus: success
+                    uploadedAt: '2026-01-01T00:00:00Z'
+                    extractedAt: '2026-01-01T00:00:02Z'
+                    extractedText: Spring Boot 백엔드 개발자입니다.
+        '401':
+          description: 인증 필요
   /documents/{documentId}:
     get:
       tags:


### PR DESCRIPTION
## 🔗 Issue 번호

- Close #287

## 🛠 작업 내용
  - V19__add_pgroonga_search.sql — PGroonga 확장 생성 + FTS 인덱스 (PGroonga 미설치 환경에서도 Flyway 통과하도록 fail-safe 처리)
  - DocumentRepository.search() — extracted_text + original_file_name 단일 OR 네이티브 쿼리, pgroonga_score 정렬, LIMIT 20
  - DocumentService.search() / DocumentController.GET /search — 서비스·컨트롤러 레이어 추가, 빈 쿼리 조기 반환 처리
  - docker-compose.yml — PGroonga 이미지(digest 핀)로 교체, Testcontainers와 동일한 버전·digest 사용
  - PGroongaTestcontainersConfiguration + @PGroongaIntegrationTest 메타 어노테이션 추가
  - DocumentSearchRepositoryTest — 실제 PGroonga 컨테이너 기반 통합 테스트 7개 (유저 격리, PENDING 제외, 한국어 검색, 파일명 검색 등)
  - DocumentApiTest — HTTP 레이어 검색 테스트 3개 추가
  - docs/document-domain-changes.md 업데이트

## ✅ 체크리스트

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가

이전이랑 달라진 점: docker-compose.yml의 DB 이미지가 postgres:15-alpine에서 groonga/pgroonga (PG 16)으로 바뀌었다. 기존에 로컬 DB 볼륨이 있으면 충돌할 수 있는데 그런 경우엔  기존 볼륨 삭제하고 다시 올려보기 

  docker-compose down -v  
  docker-compose up db -d
