### PR TITLE
fix: 계정전환 안되는 이슈 + Github로 로그인한 사람에게 계정전환 버튼이 보이는 문제 + Github 계정 전환 하…

### DIFF
--- a/backend/src/main/java/com/back/backend/domain/github/service/GithubConnectionService.java
+++ b/backend/src/main/java/com/back/backend/domain/github/service/GithubConnectionService.java
@@ -190,7 +190,7 @@ public class GithubConnectionService {
     }
 
     private List<GithubApiClient.GithubRepoInfo> fetchRepos(
-            GithubConnectRequest request, String login) {
+            GithubConnectRequest request) {
         // OAuth token으로 인증된 사용자의 repo 조회 (private 포함 가능)
         return githubApiClient.getAuthenticatedUserRepos(request.accessToken());
     }

--- a/backend/src/main/java/com/back/backend/domain/github/service/GithubConnectionService.java
+++ b/backend/src/main/java/com/back/backend/domain/github/service/GithubConnectionService.java
@@ -111,21 +111,20 @@ public class GithubConnectionService {
     public void saveConnectionOnly(User user, Long githubUserId, String githubLogin, String token) {
         Instant now = Instant.now();
 
-        // 1순위: 현재 app 사용자로 찾기
-        // 2순위: GitHub 계정 ID로 찾기 — 이미 다른 app user에 연결된 경우 차단
-        connectionRepository.findByUser(user)
-                .or(() -> connectionRepository.findByGithubUserId(githubUserId))
+        Optional<GithubConnection> byUser = connectionRepository.findByUser(user);
+        Optional<GithubConnection> byGithubId = connectionRepository.findByGithubUserId(githubUserId);
+
+        // github_user_id가 다른 app 사용자에게 이미 연결된 경우 → 차단
+        if (byGithubId.isPresent() && !byGithubId.get().getUser().getId().equals(user.getId())) {
+            throw new ServiceException(ErrorCode.REQUEST_VALIDATION_FAILED,
+                    HttpStatus.CONFLICT,
+                    "이 GitHub 계정은 이미 다른 사용자와 연결되어 있습니다. " +
+                    "다른 GitHub 계정을 사용하거나, 해당 계정으로 로그인하세요.");
+        }
+
+        byUser.or(() -> byGithubId)
                 .ifPresentOrElse(
-                        existing -> {
-                            // 다른 app 사용자가 이미 이 GitHub 계정을 연결한 경우 → 차단
-                            if (!existing.getUser().getId().equals(user.getId())) {
-                                throw new ServiceException(ErrorCode.REQUEST_VALIDATION_FAILED,
-                                        HttpStatus.CONFLICT,
-                                        "이 GitHub 계정은 이미 다른 사용자와 연결되어 있습니다. " +
-                                        "다른 GitHub 계정을 사용하거나, 해당 계정으로 로그인하세요.");
-                            }
-                            existing.update(githubUserId, githubLogin, token, null, now);
-                        },
+                        existing -> existing.update(githubUserId, githubLogin, token, null, now),
                         () -> connectionRepository.save(GithubConnection.builder()
                                 .user(user)
                                 .githubUserId(githubUserId)
@@ -210,20 +209,24 @@ public class GithubConnectionService {
     ) {
         Instant now = Instant.now();
 
-        // 기존 연결 조회 전략:
-        //   1순위: 현재 app 사용자(user_id)로 찾기
-        //   2순위: GitHub 계정(github_user_id)으로 찾기 — OAuth 로그인 시 saveConnectionOnly가
-        //          먼저 만들었지만 findByUser가 놓친 경우(예: 멀티 소셜 계정 시나리오) 대비
-        GithubConnection connection = connectionRepository.findByUser(user)
-                .or(() -> connectionRepository.findByGithubUserId(githubUser.id()))
+        // 두 축으로 별도 조회:
+        //   byUser    — 현재 app 사용자의 기존 연결 행 (있으면 갱신 대상)
+        //   byGithubId — 연결하려는 GitHub 계정이 이미 어딘가에 연결된 행
+        // .or() 체인을 쓰면 byUser가 있을 때 byGithubId를 아예 조회하지 않아
+        // "다른 사용자가 점유한 github_user_id를 덮어쓰기" 하는 unique 제약 위반이 발생한다.
+        Optional<GithubConnection> byUser = connectionRepository.findByUser(user);
+        Optional<GithubConnection> byGithubId = connectionRepository.findByGithubUserId(githubUser.id());
+
+        // github_user_id가 다른 app 사용자에게 이미 연결된 경우 → 차단
+        if (byGithubId.isPresent() && !byGithubId.get().getUser().getId().equals(user.getId())) {
+            throw new ServiceException(ErrorCode.REQUEST_VALIDATION_FAILED,
+                    HttpStatus.CONFLICT,
+                    "이 GitHub 계정은 이미 다른 사용자와 연결되어 있습니다. " +
+                    "다른 GitHub 계정을 사용하거나, 해당 계정으로 로그인하세요.");
+        }
+
+        GithubConnection connection = byUser.or(() -> byGithubId)
                 .map(existing -> {
-                    // 다른 app 사용자가 이미 이 GitHub 계정을 연결한 경우 → 차단
-                    if (!existing.getUser().getId().equals(user.getId())) {
-                        throw new ServiceException(ErrorCode.REQUEST_VALIDATION_FAILED,
-                                HttpStatus.CONFLICT,
-                                "이 GitHub 계정은 이미 다른 사용자와 연결되어 있습니다. " +
-                                "다른 GitHub 계정을 사용하거나, 해당 계정으로 로그인하세요.");
-                    }
                     log.info("Updating existing GitHub connection for userId={}", user.getId());
                     existing.update(
                             githubUser.id(), githubUser.login(),

--- a/backend/src/main/java/com/back/backend/domain/github/service/GithubConnectionService.java
+++ b/backend/src/main/java/com/back/backend/domain/github/service/GithubConnectionService.java
@@ -190,7 +190,7 @@ public class GithubConnectionService {
     }
 
     private List<GithubApiClient.GithubRepoInfo> fetchRepos(
-            GithubConnectRequest request) {
+            GithubConnectRequest request, String login) {
         // OAuth token으로 인증된 사용자의 repo 조회 (private 포함 가능)
         return githubApiClient.getAuthenticatedUserRepos(request.accessToken());
     }

--- a/frontend/app/portfolio/github/page.tsx
+++ b/frontend/app/portfolio/github/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { refreshGithubConnection, getGithubConnection } from '@/api/github';
 import { getMe, getGithubLinkUrl } from '@/api/auth';
 import type { GithubConnection } from '@/types/github';
@@ -47,6 +48,19 @@ export default function GithubConnectPage() {
       })
       .finally(() => setLoading(false));
   }, []);
+
+  // ── 기존 연결 재확인 후 복원 (변경 취소 시) ───────────────────
+  async function handleRestoreExistingConnection() {
+    setSubmitting(true);
+    setApiError(null);
+    try {
+      const connection = await getGithubConnection().catch(() => null);
+      setExistingConnection(connection);
+      setForceReconnect(false);
+    } finally {
+      setSubmitting(false);
+    }
+  }
 
   // ── GitHub OAuth 연동 (Google/Kakao 사용자) ──────────────────
   async function handleGithubOAuthLink() {
@@ -143,36 +157,56 @@ export default function GithubConnectPage() {
       <main className="mx-auto max-w-lg px-4 py-12">
         <h1 className="mb-2 text-2xl font-semibold">GitHub 연결</h1>
 
-        <div className="rounded border border-green-100 bg-green-50 px-4 py-4 mb-6">
+        <div className="rounded border border-green-100 bg-green-50 px-4 py-4 mb-4">
           <p className="text-sm font-medium text-green-800 mb-1">GitHub 계정이 연결되었습니다</p>
           <p className="text-sm text-green-700">
             <span className="font-medium">{existingConnection.githubLogin}</span> 계정이 연결되어 있습니다.
           </p>
         </div>
 
-        <div className="flex flex-col gap-3">
-          <button
-            onClick={handleGoToRepositories}
-            className="w-full rounded bg-zinc-900 py-2.5 text-sm font-medium text-white"
-          >
-            repository 선택하기 →
-          </button>
-          {!providers.includes('github') && (
-            <button
-              onClick={() => { setExistingConnection(null); setForceReconnect(true); }}
-              className="text-sm text-zinc-500 underline"
-            >
-              다른 GitHub 계정으로 변경하기
-            </button>
-          )}
-        </div>
+        {(!providers.includes('github') || providers.some((p) => p !== 'github')) && (
+          <>
+            <div className="rounded border border-blue-100 bg-blue-50 px-4 py-3 mb-4 text-xs text-blue-700">
+              <p className="font-medium text-blue-800 mb-1">연결할 GitHub 계정을 먼저 확인하세요</p>
+              <p>
+                계정을 변경하면 현재 브라우저에 로그인된 GitHub 계정이 자동으로 연결됩니다.
+                다른 계정으로 변경하려면 먼저{' '}
+                <a
+                  href="https://github.com/login"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline text-blue-600"
+                >
+                  GitHub에서 계정을 전환
+                </a>
+                한 후 진행하세요.
+              </p>
+            </div>
+            <div className="mb-3">
+              <button
+                onClick={() => { setExistingConnection(null); setForceReconnect(true); }}
+                className="text-sm text-zinc-500 underline"
+              >
+                다른 GitHub 계정으로 변경하기
+              </button>
+            </div>
+          </>
+        )}
+
+        <Link
+          href="/portfolio"
+          className="block w-full rounded bg-zinc-900 py-2.5 text-center text-sm font-medium text-white"
+        >
+          포트폴리오로 돌아가기
+        </Link>
+
       </main>
     );
   }
 
   // ── GitHub OAuth로 로그인한 사용자 (연결 없음) ────────────
   // 로그인 시점에 token이 저장되므로 별도 입력 없이 repo를 가져올 수 있다.
-  if (providers.includes('github') && !forceReconnect) {
+  if (providers.every((p) => p === 'github') && !forceReconnect) {
     return (
       <main className="mx-auto max-w-lg px-4 py-12">
         <h1 className="mb-2 text-2xl font-semibold">GitHub 연결</h1>
@@ -239,10 +273,43 @@ export default function GithubConnectPage() {
         </ul>
       </div>
 
+      {/* 브라우저 세션 경고: 현재 GitHub 로그인 계정이 자동 연동됨을 알림 */}
+      <div className="rounded border border-blue-100 bg-blue-50 px-4 py-3 mb-4 text-xs text-blue-700">
+        <p className="font-medium text-blue-800 mb-1">연결할 GitHub 계정을 먼저 확인하세요</p>
+        <p>
+          아래 버튼을 누르면 현재 브라우저에 로그인된 GitHub 계정이 자동으로 연결됩니다.
+          다른 계정을 연결하려면 먼저{' '}
+          <a
+            href="https://github.com/login"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline text-blue-600"
+          >
+            GitHub에서 계정을 전환
+          </a>
+          한 후 진행하세요.
+        </p>
+      </div>
+
       {apiError && (
-        <div className="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 whitespace-pre-line">
-          {apiError}
-          <button type="button" onClick={() => setApiError(null)} className="ml-2 underline text-red-500">닫기</button>
+        <div className="mb-4 rounded border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <p className="whitespace-pre-line">{apiError}</p>
+          {forceReconnect && (
+            <p className="mt-2 text-xs text-red-600">
+              현재 브라우저에 로그인된 GitHub 계정이 자동으로 사용되었습니다.
+              연결하려는 계정으로 먼저{' '}
+              <a
+                href="https://github.com/login"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline"
+              >
+                GitHub에 로그인
+              </a>
+              한 후 다시 시도하거나, 아래 버튼으로 기존 연결을 유지하세요.
+            </p>
+          )}
+          <button type="button" onClick={() => setApiError(null)} className="mt-2 underline text-red-500 text-xs">닫기</button>
         </div>
       )}
 
@@ -256,6 +323,17 @@ export default function GithubConnectPage() {
       <p className="mt-3 text-xs text-zinc-400">
         • GitHub 로그인 페이지로 이동합니다. 완료 후 이 페이지로 돌아옵니다.
       </p>
+
+      {forceReconnect && (
+        <button
+          type="button"
+          onClick={handleRestoreExistingConnection}
+          disabled={submitting}
+          className="mt-3 w-full rounded border border-zinc-300 py-2.5 text-sm font-medium text-zinc-600 disabled:opacity-50 hover:bg-zinc-50"
+        >
+          {submitting ? '확인 중...' : '기존 연결 유지하기'}
+        </button>
+      )}
     </main>
   );
 }

--- a/frontend/app/portfolio/page.tsx
+++ b/frontend/app/portfolio/page.tsx
@@ -47,7 +47,7 @@ export default function PortfolioPage() {
                   href="/portfolio/github"
                   className="rounded border border-zinc-300 px-4 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50"
                 >
-                  변경하기
+                  연결 설정
                 </Link>
               ) : (
                 <Link

--- a/frontend/app/portfolio/repositories/page.tsx
+++ b/frontend/app/portfolio/repositories/page.tsx
@@ -12,6 +12,7 @@ import {
   addContributionByUrl,
   removeRepository,
   refreshGithubConnection,
+  getGithubConnection,
 } from '@/api/github';
 import { useBatchAnalysis } from '@/context/BatchAnalysisContext';
 import ResyncConfirmModal from '@/components/ResyncConfirmModal';
@@ -53,12 +54,22 @@ type Tab = 'owned' | 'contributed';
 
 export default function RepositoriesPage() {
   const [activeTab, setActiveTab] = useState<Tab>('owned');
+  const [githubLogin, setGithubLogin] = useState<string | null>(null);
+
+  useEffect(() => {
+    getGithubConnection().then((c) => setGithubLogin(c?.githubLogin ?? null)).catch(() => {});
+  }, []);
 
   return (
     <main className="mx-auto max-w-2xl px-4 py-10">
       <h1 className="mb-1 text-xl font-semibold">Repository 관리</h1>
       <p className="mb-5 text-sm text-zinc-500">
         포트폴리오에 활용할 repository를 선택하고 분석을 시작하세요.
+        {githubLogin && (
+          <span className="ml-1 text-zinc-400">
+            (현재 브라우저에 <span className="font-medium text-zinc-600">{githubLogin}</span> 계정으로 로그인되어 있어야 합니다.)
+          </span>
+        )}
       </p>
 
       <div className="mb-6 flex rounded border border-zinc-200">


### PR DESCRIPTION
…는 법에 대해 안내문 추가해 혼동을 없앰 + 버튼 이름을 변경 등

## 🔗 Issue 번호

- Close #385

  GitHub 연결 페이지 (/portfolio/github) UX 개선

  - "변경하기" 버튼이 동작하지 않던 문제 수정: Google/Kakao 사용자도 "다른 GitHub 계정으로 변경하기" 버튼이 보이도록 수정
  - GitHub 전용 로그인 사용자 처리 분리: GitHub으로만 가입한 사용자는 변경 버튼 및 안내문 자체를 숨김 (계정 변경이 불가능하므로)
  - 브라우저 세션 경고 추가: "현재 브라우저에 로그인된 GitHub 계정이 자동 연동된다"는 안내를 미리 표시
  - 오류 발생 시 안내 개선: OAuth 충돌 에러 발생 시 원인 설명 + "기존 연결 유지하기" 버튼 추가
  - providers 조건 버그 수정: every() 대신 includes()+some() 조합으로 빈 배열 엣지케이스 및 멀티 프로바이더 계정 오판 방지
  - repository 선택 버튼 제거 후 "포트폴리오로 돌아가기" 버튼으로 교체

  ---
  GitHub 연결 충돌 버그 수정 (500 에러)

  - saveConnectionWithRepos / saveConnectionOnly의 중복 키 위반 버그 수정: .or() 체인 구조 때문에 다른 사용자가 점유한 github_user_id를 덮어쓰려다 DB 제약
  위반이 발생하던 문제를 두 쿼리를 독립 실행하여 사전 차단하도록 수정

  - 포트폴리오 홈의 "변경하기" → "연결 설정"으로 문구 변경

## ✅ 체크리스트

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?