### PR TITLE
Fix/application generate async

### DIFF
--- a/backend/src/main/java/com/back/backend/domain/ai/pipeline/AiConcurrencyLimiter.java
+++ b/backend/src/main/java/com/back/backend/domain/ai/pipeline/AiConcurrencyLimiter.java
@@ -27,7 +27,7 @@ public class AiConcurrencyLimiter {
     private final Duration queueTimeout;
 
     public AiConcurrencyLimiter(
-        @Value("${ai.concurrency.max-concurrent-calls:4}") int maxConcurrentCalls,
+        @Value("${ai.concurrency.max-concurrent-calls:20}") int maxConcurrentCalls,
         @Value("${ai.concurrency.queue-timeout-seconds:90}") long queueTimeoutSeconds
     ) {
         this.semaphore = new Semaphore(maxConcurrentCalls, true);

--- a/backend/src/main/java/com/back/backend/domain/application/controller/ApplicationAiController.java
+++ b/backend/src/main/java/com/back/backend/domain/application/controller/ApplicationAiController.java
@@ -1,17 +1,20 @@
 package com.back.backend.domain.application.controller;
 
-import com.back.backend.domain.ai.service.SelfIntroGenerateService;
-import com.back.backend.domain.ai.service.SelfIntroGenerateService.GenerateResult;
 import com.back.backend.domain.application.dto.request.GenerateAnswersRequest;
-import com.back.backend.domain.application.dto.response.ApplicationAnswerGenerationResponse;
+import com.back.backend.domain.application.dto.response.ApplicationAiGenerationStatusResponse;
+import com.back.backend.domain.application.service.ApplicationAiGenerationJobStore;
+import com.back.backend.domain.application.service.AsyncSelfIntroGenerateService;
 import com.back.backend.global.response.ApiResponse;
 import com.back.backend.global.security.auth.CurrentUserResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,28 +22,54 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ApplicationAiController {
 
-    private final SelfIntroGenerateService selfIntroGenerateService;
+    private final AsyncSelfIntroGenerateService asyncSelfIntroGenerateService;
+    private final ApplicationAiGenerationJobStore jobStore;
     private final CurrentUserResolver currentUserResolver;
 
+    /**
+     * 자소서 AI 답변 생성을 비동기로 시작한다.
+     *
+     * <p>소유권 검증 후 작업을 applicationAiTaskExecutor 큐에 밀어 넣고
+     * 즉시 202 Accepted를 반환한다.</p>
+     *
+     * <p>이미 PENDING/IN_PROGRESS 상태면 중복 제출 없이 현재 상태를 202로 반환한다.</p>
+     *
+     * <p>진행 상황은 GET .../generate-answers/status 폴링으로 확인한다.</p>
+     */
     @PostMapping("/{applicationId}/questions/generate-answers")
-    public ApiResponse<ApplicationAnswerGenerationResponse> generateAnswers(
-        Authentication authentication,
-        @PathVariable long applicationId,
-        @RequestBody GenerateAnswersRequest request
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public ApiResponse<ApplicationAiGenerationStatusResponse> generateAnswers(
+            Authentication authentication,
+            @PathVariable long applicationId,
+            @RequestBody GenerateAnswersRequest request
     ) {
         long userId = currentUserResolver.resolveUserId(authentication);
+        asyncSelfIntroGenerateService.validateOwnership(userId, applicationId);
+        asyncSelfIntroGenerateService.submitAsync(userId, applicationId, request.regenerate());
 
-        GenerateResult result = selfIntroGenerateService.generate(
-            userId, applicationId, request.regenerate()
-        );
+        ApplicationAiGenerationStatusResponse response = jobStore.get(userId, applicationId)
+                .map(data -> ApplicationAiGenerationStatusResponse.from(applicationId, data))
+                .orElseGet(() -> ApplicationAiGenerationStatusResponse.pending(applicationId));
 
-        return ApiResponse.success(
-            ApplicationAnswerGenerationResponse.of(
-                applicationId,
-                request.regenerate(),
-                result.generatedCount(),
-                result.allQuestions()
-            )
-        );
+        return ApiResponse.success(response);
+    }
+
+    /**
+     * 자소서 AI 답변 생성 진행 상태를 조회한다.
+     *
+     * <p>클라이언트는 이 API를 주기적으로 폴링하여 COMPLETED/FAILED 상태를 확인한다.
+     * TTL 만료 또는 미요청이면 data: null 반환.</p>
+     */
+    @GetMapping("/{applicationId}/questions/generate-answers/status")
+    public ApiResponse<ApplicationAiGenerationStatusResponse> getGenerateAnswersStatus(
+            Authentication authentication,
+            @PathVariable long applicationId
+    ) {
+        long userId = currentUserResolver.resolveUserId(authentication);
+        ApplicationAiGenerationStatusResponse response = jobStore.get(userId, applicationId)
+                .map(data -> ApplicationAiGenerationStatusResponse.from(applicationId, data))
+                .orElse(null);
+
+        return ApiResponse.success(response);
     }
 }

--- a/backend/src/main/java/com/back/backend/domain/application/dto/response/ApplicationAiGenerationStatusResponse.java
+++ b/backend/src/main/java/com/back/backend/domain/application/dto/response/ApplicationAiGenerationStatusResponse.java
@@ -1,0 +1,25 @@
+package com.back.backend.domain.application.dto.response;
+
+import com.back.backend.domain.application.service.ApplicationAiGenerationJobStatus;
+import com.back.backend.domain.application.service.ApplicationAiGenerationJobStore;
+
+/**
+ * 자소서 AI 생성 작업 상태 응답.
+ * GET .../generate-answers/status 폴링 시 반환된다.
+ */
+public record ApplicationAiGenerationStatusResponse(
+        long applicationId,
+        String status,
+        String error
+) {
+    public static ApplicationAiGenerationStatusResponse pending(long applicationId) {
+        return new ApplicationAiGenerationStatusResponse(
+                applicationId, ApplicationAiGenerationJobStatus.PENDING.name(), null);
+    }
+
+    public static ApplicationAiGenerationStatusResponse from(
+            long applicationId, ApplicationAiGenerationJobStore.JobData data) {
+        return new ApplicationAiGenerationStatusResponse(
+                applicationId, data.status().name(), data.error());
+    }
+}

--- a/backend/src/main/java/com/back/backend/domain/application/service/ApplicationAiGenerationJobStatus.java
+++ b/backend/src/main/java/com/back/backend/domain/application/service/ApplicationAiGenerationJobStatus.java
@@ -1,0 +1,8 @@
+package com.back.backend.domain.application.service;
+
+public enum ApplicationAiGenerationJobStatus {
+    PENDING,
+    IN_PROGRESS,
+    COMPLETED,
+    FAILED
+}

--- a/backend/src/main/java/com/back/backend/domain/application/service/ApplicationAiGenerationJobStore.java
+++ b/backend/src/main/java/com/back/backend/domain/application/service/ApplicationAiGenerationJobStore.java
@@ -1,0 +1,101 @@
+package com.back.backend.domain.application.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * 자소서 AI 답변 생성 작업 상태를 Redis에서 관리한다.
+ *
+ * Redis 키 구조:
+ *   app:ai-gen:{userId}:{applicationId}  →  JSON  TTL 10분
+ *
+ * 상태 전이:
+ *   PENDING → IN_PROGRESS → COMPLETED
+ *                         → FAILED
+ */
+@Service
+public class ApplicationAiGenerationJobStore {
+
+    private static final Logger log = LoggerFactory.getLogger(ApplicationAiGenerationJobStore.class);
+    private static final String KEY_PREFIX = "app:ai-gen:";
+    private static final Duration TTL = Duration.ofMinutes(10);
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public ApplicationAiGenerationJobStore(StringRedisTemplate redisTemplate, ObjectMapper objectMapper) {
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record JobData(
+            ApplicationAiGenerationJobStatus status,
+            Instant startedAt,
+            Instant completedAt,
+            String error
+    ) {}
+
+    public void setPending(long userId, long applicationId) {
+        save(userId, applicationId, new JobData(
+                ApplicationAiGenerationJobStatus.PENDING, Instant.now(), null, null));
+        log.info("[AppAI] PENDING: userId={}, applicationId={}", userId, applicationId);
+    }
+
+    public void setInProgress(long userId, long applicationId) {
+        Instant startedAt = get(userId, applicationId)
+                .map(JobData::startedAt)
+                .orElseGet(Instant::now);
+        save(userId, applicationId, new JobData(
+                ApplicationAiGenerationJobStatus.IN_PROGRESS, startedAt, null, null));
+        log.info("[AppAI] IN_PROGRESS: userId={}, applicationId={}", userId, applicationId);
+    }
+
+    public void setCompleted(long userId, long applicationId) {
+        Instant startedAt = get(userId, applicationId).map(JobData::startedAt).orElse(null);
+        save(userId, applicationId, new JobData(
+                ApplicationAiGenerationJobStatus.COMPLETED, startedAt, Instant.now(), null));
+        log.info("[AppAI] COMPLETED: userId={}, applicationId={}", userId, applicationId);
+    }
+
+    public void setFailed(long userId, long applicationId, String error) {
+        Instant startedAt = get(userId, applicationId).map(JobData::startedAt).orElse(null);
+        save(userId, applicationId, new JobData(
+                ApplicationAiGenerationJobStatus.FAILED, startedAt, Instant.now(), error));
+        log.warn("[AppAI] FAILED: userId={}, applicationId={}, error={}", userId, applicationId, error);
+    }
+
+    public Optional<JobData> get(long userId, long applicationId) {
+        String key = buildKey(userId, applicationId);
+        String json = redisTemplate.opsForValue().get(key);
+        if (json == null) return Optional.empty();
+        try {
+            return Optional.of(objectMapper.readValue(json, JobData.class));
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to deserialize ai-gen job for key={}: {}", key, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private void save(long userId, long applicationId, JobData data) {
+        String key = buildKey(userId, applicationId);
+        try {
+            redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(data), TTL);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize ai-gen job for key={}: {}", key, e.getMessage());
+        }
+    }
+
+    private String buildKey(long userId, long applicationId) {
+        return KEY_PREFIX + userId + ":" + applicationId;
+    }
+}

--- a/backend/src/main/java/com/back/backend/domain/application/service/AsyncSelfIntroGenerateService.java
+++ b/backend/src/main/java/com/back/backend/domain/application/service/AsyncSelfIntroGenerateService.java
@@ -33,7 +33,7 @@ public class AsyncSelfIntroGenerateService {
             SelfIntroGenerateService selfIntroGenerateService,
             ApplicationAiGenerationJobStore jobStore,
             ApplicationRepository applicationRepository,
-            @Qualifier("applicationAiTaskExecutor") Executor applicationAiTaskExecutor
+            @Qualifier("aiTaskExecutor") Executor applicationAiTaskExecutor
     ) {
         this.selfIntroGenerateService = selfIntroGenerateService;
         this.jobStore = jobStore;

--- a/backend/src/main/java/com/back/backend/domain/application/service/AsyncSelfIntroGenerateService.java
+++ b/backend/src/main/java/com/back/backend/domain/application/service/AsyncSelfIntroGenerateService.java
@@ -1,0 +1,90 @@
+package com.back.backend.domain.application.service;
+
+import com.back.backend.domain.ai.service.SelfIntroGenerateService;
+import com.back.backend.domain.application.repository.ApplicationRepository;
+import com.back.backend.global.exception.ErrorCode;
+import com.back.backend.global.exception.ServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.Executor;
+
+/**
+ * 자소서 AI 답변 생성을 비동기로 실행하는 서비스.
+ *
+ * <p>submitAsync()는 즉시 반환하고, 실제 AI 호출은 applicationAiTaskExecutor 스레드에서 실행된다.
+ * 진행 상태는 ApplicationAiGenerationJobStore(Redis)에 기록되며,
+ * 클라이언트는 GET .../generate-answers/status 폴링으로 완료 여부를 확인한다.</p>
+ */
+@Service
+public class AsyncSelfIntroGenerateService {
+
+    private static final Logger log = LoggerFactory.getLogger(AsyncSelfIntroGenerateService.class);
+
+    private final SelfIntroGenerateService selfIntroGenerateService;
+    private final ApplicationAiGenerationJobStore jobStore;
+    private final ApplicationRepository applicationRepository;
+    private final Executor applicationAiTaskExecutor;
+
+    public AsyncSelfIntroGenerateService(
+            SelfIntroGenerateService selfIntroGenerateService,
+            ApplicationAiGenerationJobStore jobStore,
+            ApplicationRepository applicationRepository,
+            @Qualifier("applicationAiTaskExecutor") Executor applicationAiTaskExecutor
+    ) {
+        this.selfIntroGenerateService = selfIntroGenerateService;
+        this.jobStore = jobStore;
+        this.applicationRepository = applicationRepository;
+        this.applicationAiTaskExecutor = applicationAiTaskExecutor;
+    }
+
+    /**
+     * applicationId가 userId에게 속하는지 검증한다.
+     * 비동기 제출 전에 호출하여 잘못된 작업이 큐에 들어가지 않도록 한다.
+     */
+    public void validateOwnership(long userId, long applicationId) {
+        applicationRepository.findByIdAndUserId(applicationId, userId)
+                .orElseThrow(() -> new ServiceException(
+                        ErrorCode.APPLICATION_NOT_FOUND,
+                        HttpStatus.NOT_FOUND,
+                        "지원 준비를 찾을 수 없습니다."
+                ));
+    }
+
+    /**
+     * AI 자소서 생성 작업을 비동기로 제출한다.
+     *
+     * <p>이미 PENDING/IN_PROGRESS 상태이면 중복 제출 없이 idempotent하게 반환한다.
+     * 소유권 검증은 {@link #validateOwnership(long, long)}을 먼저 호출해야 한다.</p>
+     */
+    public void submitAsync(long userId, long applicationId, boolean regenerate) {
+        ApplicationAiGenerationJobStore.JobData existing = jobStore.get(userId, applicationId).orElse(null);
+        if (existing != null && isInFlight(existing.status())) {
+            log.info("[AppAI] 이미 진행 중 — skip: userId={}, applicationId={}, status={}",
+                    userId, applicationId, existing.status());
+            return;
+        }
+
+        jobStore.setPending(userId, applicationId);
+
+        applicationAiTaskExecutor.execute(() -> {
+            jobStore.setInProgress(userId, applicationId);
+            try {
+                selfIntroGenerateService.generate(userId, applicationId, regenerate);
+                jobStore.setCompleted(userId, applicationId);
+            } catch (Exception e) {
+                String error = e.getMessage() != null ? e.getMessage() : "알 수 없는 오류";
+                jobStore.setFailed(userId, applicationId, error);
+                log.warn("[AppAI] 생성 실패: userId={}, applicationId={}, error={}", userId, applicationId, error);
+            }
+        });
+    }
+
+    private boolean isInFlight(ApplicationAiGenerationJobStatus status) {
+        return status == ApplicationAiGenerationJobStatus.PENDING
+                || status == ApplicationAiGenerationJobStatus.IN_PROGRESS;
+    }
+}

--- a/backend/src/main/java/com/back/backend/domain/interview/controller/InterviewSessionController.java
+++ b/backend/src/main/java/com/back/backend/domain/interview/controller/InterviewSessionController.java
@@ -82,6 +82,7 @@ public class InterviewSessionController {
     }
 
     @PostMapping("/{sessionId}/complete")
+    @ResponseStatus(HttpStatus.ACCEPTED)
     public ApiResponse<InterviewSessionCompletionResponse> completeSession(
             Authentication authentication,
             @PathVariable long sessionId

--- a/backend/src/main/java/com/back/backend/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/back/backend/global/config/AsyncConfig.java
@@ -65,23 +65,4 @@ public class AsyncConfig {
         return executor;
     }
 
-    /**
-     * 자소서 AI 답변 생성 전용 Executor.
-     *
-     * <p>aiTaskExecutor(면접 결과)와 분리하여 자소서 생성 요청이 몰려도
-     * 면접 결과 생성 처리에 영향을 주지 않도록 격리한다.
-     * core=2, max=4, queue=100 — K6 VU 수 기준.
-     * CallerRunsPolicy로 큐 포화 시 호출 스레드에서 동기 실행(graceful degradation).</p>
-     */
-    @Bean("applicationAiTaskExecutor")
-    public Executor applicationAiTaskExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(2);
-        executor.setMaxPoolSize(4);
-        executor.setQueueCapacity(100);
-        executor.setThreadNamePrefix("app-ai-");
-        executor.setRejectedExecutionHandler(new java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy());
-        executor.initialize();
-        return executor;
-    }
 }

--- a/backend/src/main/java/com/back/backend/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/back/backend/global/config/AsyncConfig.java
@@ -64,4 +64,24 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    /**
+     * 자소서 AI 답변 생성 전용 Executor.
+     *
+     * <p>aiTaskExecutor(면접 결과)와 분리하여 자소서 생성 요청이 몰려도
+     * 면접 결과 생성 처리에 영향을 주지 않도록 격리한다.
+     * core=2, max=4, queue=100 — K6 VU 수 기준.
+     * CallerRunsPolicy로 큐 포화 시 호출 스레드에서 동기 실행(graceful degradation).</p>
+     */
+    @Bean("applicationAiTaskExecutor")
+    public Executor applicationAiTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("app-ai-");
+        executor.setRejectedExecutionHandler(new java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
 }

--- a/backend/src/test/java/com/back/backend/domain/application/controller/ApplicationAiApiTest.java
+++ b/backend/src/test/java/com/back/backend/domain/application/controller/ApplicationAiApiTest.java
@@ -21,11 +21,15 @@ import jakarta.persistence.EntityManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import java.time.Instant;
+import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -37,7 +41,20 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Transactional
+@Import(ApplicationAiApiTest.SyncExecutorConfig.class)
 class ApplicationAiApiTest extends ApiTestBase {
+
+    /**
+     * aiTaskExecutor를 동기 실행으로 오버라이드 — @Transactional 테스트에서
+     * 비동기 AI 생성이 같은 스레드/트랜잭션에서 실행되어야 테스트 데이터가 보임
+     */
+    @TestConfiguration
+    static class SyncExecutorConfig {
+        @Bean("aiTaskExecutor")
+        public Executor aiTaskExecutor() {
+            return Runnable::run;
+        }
+    }
 
     private static final Instant NOW = Instant.parse("2026-03-25T09:00:00Z");
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -72,17 +89,10 @@ class ApplicationAiApiTest extends ApiTestBase {
                 .contentType("application/json")
                 .content(OBJECT_MAPPER.writeValueAsString(
                     new GenerateAnswersRequest(true, false))))
-            .andExpect(status().isOk())
+            .andExpect(status().isAccepted())
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.applicationId").value(application.getId()))
-            .andExpect(jsonPath("$.data.generatedCount").value(1))
-            .andExpect(jsonPath("$.data.regenerate").value(false))
-            .andExpect(jsonPath("$.data.answers.length()").value(1))
-            .andExpect(jsonPath("$.data.answers[0].questionText").value("지원 동기를 작성해주세요"))
-            .andExpect(jsonPath("$.data.answers[0].generatedAnswer")
-                .value("카카오의 기술 문화에 깊은 관심을 가지고 있습니다."))
-            .andExpect(jsonPath("$.data.answers[0].toneOption").value("formal"))
-            .andExpect(jsonPath("$.data.answers[0].lengthOption").value("medium"));
+            .andExpect(jsonPath("$.data.status").value("COMPLETED"));
 
         entityManager.flush();
         entityManager.clear();
@@ -113,11 +123,9 @@ class ApplicationAiApiTest extends ApiTestBase {
                 .contentType("application/json")
                 .content(OBJECT_MAPPER.writeValueAsString(
                     new GenerateAnswersRequest(true, false))))
-            .andExpect(status().isOk())
-            .andExpect(jsonPath("$.data.generatedCount").value(1))
-            .andExpect(jsonPath("$.data.answers.length()").value(2))
-            .andExpect(jsonPath("$.data.answers[0].generatedAnswer").value("기존 답변"))
-            .andExpect(jsonPath("$.data.answers[1].generatedAnswer").value("새로 생성된 답변"));
+            .andExpect(status().isAccepted())
+            .andExpect(jsonPath("$.data.applicationId").value(application.getId()))
+            .andExpect(jsonPath("$.data.status").value("COMPLETED"));
     }
 
     @Test
@@ -157,8 +165,9 @@ class ApplicationAiApiTest extends ApiTestBase {
                 .contentType("application/json")
                 .content(OBJECT_MAPPER.writeValueAsString(
                     new GenerateAnswersRequest(true, false))))
-            .andExpect(status().isUnprocessableEntity())
-            .andExpect(jsonPath("$.error.code").value(ErrorCode.APPLICATION_QUESTION_REQUIRED.name()));
+            .andExpect(status().isAccepted())
+            .andExpect(jsonPath("$.data.applicationId").value(application.getId()))
+            .andExpect(jsonPath("$.data.status").value("FAILED"));
     }
 
     // --- 헬퍼 ---

--- a/backend/src/test/java/com/back/backend/domain/interview/controller/InterviewSessionCompleteApiTest.java
+++ b/backend/src/test/java/com/back/backend/domain/interview/controller/InterviewSessionCompleteApiTest.java
@@ -159,7 +159,7 @@ class InterviewSessionCompleteApiTest extends ApiTestBase {
 
         mockMvc.perform(post("/api/v1/interview/sessions/{sessionId}/complete", session.getId())
                         .with(authenticated(fixture.user().getId())))
-                .andExpect(status().isOk())
+                .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.sessionId").value(session.getId()))
                 .andExpect(jsonPath("$.data.status").value("feedback_completed"))
@@ -203,7 +203,7 @@ class InterviewSessionCompleteApiTest extends ApiTestBase {
 
         mockMvc.perform(post("/api/v1/interview/sessions/{sessionId}/complete", session.getId())
                         .with(authenticated(fixture.user().getId())))
-                .andExpect(status().isOk())
+                .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$.data.status").value("feedback_completed"))
                 .andExpect(jsonPath("$.data.totalScore").value(86))
                 .andExpect(jsonPath("$.data.summaryFeedback").value("동적 꼬리질문 답변까지 포함해 평가했습니다."));
@@ -461,7 +461,7 @@ class InterviewSessionCompleteApiTest extends ApiTestBase {
 
         mockMvc.perform(post("/api/v1/interview/sessions/{sessionId}/complete", session.getId())
                         .with(authenticated(fixture.user().getId())))
-                .andExpect(status().isOk())
+                .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$.data.status").value("feedback_completed"))
                 .andExpect(jsonPath("$.data.totalScore").value(83));
 
@@ -543,7 +543,7 @@ class InterviewSessionCompleteApiTest extends ApiTestBase {
 
         mockMvc.perform(post("/api/v1/interview/sessions/{sessionId}/complete", session.getId())
                         .with(authenticated(fixture.user().getId())))
-                .andExpect(status().isOk())
+                .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$.data.status").value("feedback_completed"))
                 .andExpect(jsonPath("$.data.totalScore").value(85));
 
@@ -584,7 +584,7 @@ class InterviewSessionCompleteApiTest extends ApiTestBase {
 
         mockMvc.perform(post("/api/v1/interview/sessions/{sessionId}/complete", session.getId())
                         .with(authenticated(fixture.user().getId())))
-                .andExpect(status().isOk())
+                .andExpect(status().isAccepted())
                 .andExpect(jsonPath("$.data.status").value("feedback_completed"))
                 .andExpect(jsonPath("$.data.totalScore").value(82));
 

--- a/frontend/api/application.ts
+++ b/frontend/api/application.ts
@@ -2,8 +2,8 @@ import type {
   Application,
   ApplicationQuestion,
   CreateApplicationRequest,
+  GenerateAnswersJobResponse,
   GenerateAnswersRequest,
-  GenerateAnswersResponse,
   SaveQuestionsRequest,
   SaveSourcesRequest,
   SourceBindingResponse,
@@ -165,12 +165,14 @@ export async function getQuestions(applicationId: number): Promise<ApplicationQu
 
 /**
  * POST /applications/{applicationId}/questions/generate-answers
- * AI 자기소개서 답변 생성.
+ * AI 자기소개서 답변 생성 작업을 비동기로 시작한다.
+ * 서버는 즉시 202 Accepted + { status: "PENDING" }을 반환한다.
+ * 완료 여부는 getGenerateAnswersStatus()로 폴링한다.
  */
 export async function generateAnswers(
   applicationId: number,
   request: GenerateAnswersRequest,
-): Promise<GenerateAnswersResponse> {
+): Promise<GenerateAnswersJobResponse> {
   const res = await apiFetch(`/api/v1/applications/${applicationId}/questions/generate-answers`, {
     method: 'POST',
     body: JSON.stringify(request),
@@ -181,5 +183,26 @@ export async function generateAnswers(
   }
 
   const body = await res.json();
-  return body.data as GenerateAnswersResponse;
+  return body.data as GenerateAnswersJobResponse;
+}
+
+/**
+ * GET /applications/{applicationId}/questions/generate-answers/status
+ * AI 자기소개서 답변 생성 진행 상태를 폴링한다.
+ * 작업이 없거나 TTL 만료이면 null 반환.
+ */
+export async function getGenerateAnswersStatus(
+  applicationId: number,
+): Promise<GenerateAnswersJobResponse | null> {
+  const res = await apiFetch(
+    `/api/v1/applications/${applicationId}/questions/generate-answers/status`,
+    { cache: 'no-store' },
+  );
+
+  if (!res.ok) {
+    throw new Error(await parseError(res));
+  }
+
+  const body = await res.json();
+  return body.data as GenerateAnswersJobResponse | null;
 }

--- a/frontend/app/applications/[id]/generate/page.tsx
+++ b/frontend/app/applications/[id]/generate/page.tsx
@@ -1,13 +1,12 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState, useCallback } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import { getApplication, getQuestions, generateAnswers } from '@/api/application';
+import { useEffect, useState, useCallback, useRef } from 'react';
+import { useParams } from 'next/navigation';
+import { getApplication, getQuestions, generateAnswers, getGenerateAnswersStatus } from '@/api/application';
 import AiGenerationStatusCard from '@/components/AiGenerationStatusCard';
-import type { ApplicationQuestion, GeneratedAnswerItem } from '@/types/application';
+import type { ApplicationQuestion } from '@/types/application';
 
-// 톤/길이 옵션 한글 라벨
 const TONE_LABEL: Record<string, string> = {
   formal: '격식체',
   casual: '구어체',
@@ -20,12 +19,12 @@ const LENGTH_LABEL: Record<string, string> = {
   long: '길게 (1400자 내외)',
 };
 
+const POLL_INTERVAL_MS = 3000;
+
 export default function GeneratePage() {
   const params = useParams();
-  const router = useRouter();
   const applicationId = Number(params.id);
 
-  // 문항 목록
   const [questions, setQuestions] = useState<ApplicationQuestion[]>([]);
   const [applicationStatus, setApplicationStatus] = useState<'draft' | 'ready' | null>(null);
   const [loading, setLoading] = useState(true);
@@ -34,10 +33,12 @@ export default function GeneratePage() {
   // 생성 상태
   const [generating, setGenerating] = useState(false);
   const [generateError, setGenerateError] = useState<string | null>(null);
-  const [result, setResult] = useState<GeneratedAnswerItem[] | null>(null);
-  const [generatedCount, setGeneratedCount] = useState(0);
+  const [generationDone, setGenerationDone] = useState(false);
   const [showLongWaitHint, setShowLongWaitHint] = useState(false);
   const [showRegenerateConfirm, setShowRegenerateConfirm] = useState(false);
+
+  const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const generatingStartRef = useRef<number | null>(null);
 
   // ── 문항 목록 조회 ─────────────────────────────────
   const loadPageData = useCallback(async () => {
@@ -58,41 +59,105 @@ export default function GeneratePage() {
     }
   }, [applicationId]);
 
-  useEffect(() => {
-    loadPageData();
-  }, [loadPageData]);
+  // ── 폴링 중단 ─────────────────────────────────────
+  const stopPolling = useCallback(() => {
+    if (pollingRef.current !== null) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+  }, []);
 
+  // ── 폴링 시작 ─────────────────────────────────────
+  // PENDING/IN_PROGRESS 동안 3초마다 상태 확인.
+  // COMPLETED → 문항 목록 리로드 + 성공 표시
+  // FAILED    → 에러 표시
+  const startPolling = useCallback(() => {
+    if (pollingRef.current !== null) return; // 이미 폴링 중
+
+    pollingRef.current = setInterval(async () => {
+      try {
+        const job = await getGenerateAnswersStatus(applicationId);
+
+        if (job === null) {
+          // TTL 만료: 상태 알 수 없음 → 결과 조회로 판단
+          stopPolling();
+          setGenerating(false);
+          await loadPageData();
+          return;
+        }
+
+        if (job.status === 'COMPLETED') {
+          stopPolling();
+          setGenerating(false);
+          setGenerationDone(true);
+          await loadPageData();
+          return;
+        }
+
+        if (job.status === 'FAILED') {
+          stopPolling();
+          setGenerating(false);
+          setGenerateError(job.error ?? 'AI 답변 생성 중 오류가 발생했습니다.');
+          return;
+        }
+
+        // PENDING / IN_PROGRESS: 경과 시간에 따라 힌트 표시
+        if (generatingStartRef.current !== null) {
+          const elapsed = Date.now() - generatingStartRef.current;
+          if (elapsed > 8000) setShowLongWaitHint(true);
+        }
+      } catch {
+        // 일시적 네트워크 오류는 무시하고 다음 폴링에서 재시도
+      }
+    }, POLL_INTERVAL_MS);
+  }, [applicationId, loadPageData, stopPolling]);
+
+  // ── 마운트 시: 진행 중인 작업 복구 ──────────────────
+  // 사용자가 탭을 닫고 다시 돌아왔을 때 PENDING/IN_PROGRESS이면 자동으로 폴링 재개
   useEffect(() => {
-    if (!generating) {
-      setShowLongWaitHint(false);
-      return;
+    let cancelled = false;
+
+    async function init() {
+      await loadPageData();
+      if (cancelled) return;
+
+      try {
+        const job = await getGenerateAnswersStatus(applicationId);
+        if (cancelled) return;
+
+        if (job?.status === 'PENDING' || job?.status === 'IN_PROGRESS') {
+          generatingStartRef.current = Date.now();
+          setGenerating(true);
+          startPolling();
+        } else if (job?.status === 'FAILED') {
+          setGenerateError(job.error ?? 'AI 답변 생성 중 오류가 발생했습니다.');
+        }
+      } catch {
+        // 상태 조회 실패는 무시: 일반 화면으로 표시
+      }
     }
 
-    const timer = window.setTimeout(() => {
-      setShowLongWaitHint(true);
-    }, 8000);
+    init();
+    return () => {
+      cancelled = true;
+      stopPolling();
+    };
+  }, [applicationId, loadPageData, startPolling, stopPolling]);
 
-    return () => window.clearTimeout(timer);
-  }, [generating]);
-
-  // ── AI 답변 생성 ──────────────────────────────────
+  // ── AI 답변 생성 시작 ─────────────────────────────
   async function handleGenerate() {
     setGenerating(true);
     setGenerateError(null);
-    setResult(null);
+    setGenerationDone(false);
+    setShowLongWaitHint(false);
+    generatingStartRef.current = Date.now();
+
     try {
-      const res = await generateAnswers(applicationId, {
-        useTemplate: true,
-        regenerate: false,
-      });
-      setResult(res.answers);
-      setGeneratedCount(res.generatedCount);
-      // 생성 후 문항 목록과 상태를 함께 다시 읽어 게이팅 기준을 맞춘다.
-      await loadPageData();
+      await generateAnswers(applicationId, { useTemplate: true, regenerate: false });
+      startPolling();
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'AI 답변 생성 중 오류가 발생했습니다.';
+      const msg = err instanceof Error ? err.message : 'AI 답변 생성 요청 중 오류가 발생했습니다.';
       setGenerateError(msg);
-    } finally {
       setGenerating(false);
     }
   }
@@ -132,9 +197,13 @@ export default function GeneratePage() {
   }
 
   const hasAnyAnswer = questions.some((q) => q.generatedAnswer !== null);
+
   const generateStatusDetail = showLongWaitHint
     ? '조금 더 걸리고 있습니다. 곧 결과를 보여드립니다.'
-    : '보통 10~30초 정도 걸립니다. 중복으로 누를 필요 없습니다.';
+    : '보통 10~30초 정도 걸립니다. 창을 닫아도 생성은 계속됩니다.';
+
+  const showSuccessCard =
+    !generating && !generateError && (generationDone || (applicationStatus === 'ready' && hasAnyAnswer));
 
   return (
     <main className="mx-auto max-w-2xl px-4 py-10">
@@ -151,7 +220,7 @@ export default function GeneratePage() {
         </p>
       </div>
 
-      {/* 생성 버튼 영역 (카드 목록 위, 오른쪽 정렬) */}
+      {/* 생성 버튼 영역 */}
       <div className="mb-4 flex items-center justify-end gap-3">
         {hasAnyAnswer && (
           <button
@@ -159,7 +228,6 @@ export default function GeneratePage() {
             title="재생성"
             className="flex items-center gap-1 text-zinc-400 hover:text-zinc-600 transition-colors"
           >
-            {/* 새로고침 아이콘 */}
             <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
             </svg>
@@ -195,7 +263,7 @@ export default function GeneratePage() {
               <button
                 onClick={() => {
                   setShowRegenerateConfirm(false);
-                  router.push(`/applications/${applicationId}?edit=true`);
+                  window.location.href = `/applications/${applicationId}?edit=true`;
                 }}
                 className="rounded bg-zinc-900 px-3 py-1.5 text-sm font-medium text-white"
               >
@@ -217,7 +285,6 @@ export default function GeneratePage() {
               <div className="flex-1 min-w-0">
                 <p className="text-sm font-medium text-zinc-900">{q.questionText}</p>
 
-                {/* 옵션 태그 */}
                 <div className="mt-1.5 flex flex-wrap gap-1.5">
                   {q.toneOption && (
                     <span className="rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-700">
@@ -236,7 +303,15 @@ export default function GeneratePage() {
                   )}
                 </div>
 
-                {/* 기존 생성 답변 */}
+                {/* 생성 중일 때 skeleton */}
+                {generating && !q.generatedAnswer && (
+                  <div className="mt-3 rounded bg-zinc-100 px-3 py-2 animate-pulse">
+                    <div className="h-3 w-1/3 rounded bg-zinc-200 mb-2" />
+                    <div className="h-3 w-full rounded bg-zinc-200 mb-1" />
+                    <div className="h-3 w-5/6 rounded bg-zinc-200" />
+                  </div>
+                )}
+
                 {q.generatedAnswer && (
                   <div className="mt-3 rounded bg-zinc-50 px-3 py-2">
                     <p className="text-xs font-medium text-zinc-500 mb-1">AI 생성 답변</p>
@@ -250,7 +325,7 @@ export default function GeneratePage() {
       </ul>
 
       {/* 상태 카드 */}
-      {(generating || generateError || (!generating && !generateError && applicationStatus === 'ready' && hasAnyAnswer)) && (
+      {(generating || generateError || showSuccessCard) && (
         <div className="rounded border border-zinc-200 px-4 py-4">
           {generating && (
             <AiGenerationStatusCard
@@ -271,16 +346,24 @@ export default function GeneratePage() {
               title="답변 생성에 실패했습니다"
               message={generateError}
               detail="같은 화면에서 다시 생성할 수 있습니다."
+              actions={
+                <button
+                  onClick={handleGenerate}
+                  className="rounded-full bg-red-700 px-4 py-2.5 text-sm font-medium text-white"
+                >
+                  다시 시도
+                </button>
+              }
             />
           )}
 
-          {!generating && !generateError && applicationStatus === 'ready' && hasAnyAnswer && (
+          {showSuccessCard && (
             <AiGenerationStatusCard
               ariaLabel="AI 답변 생성 완료 상태"
               tone="success"
               eyebrow="AI 생성 완료"
               title="자기소개서 답변이 저장되었습니다"
-              message={result ? `${generatedCount}개 문항 생성 완료 · 저장됨` : '모든 문항 답변이 준비되었습니다.'}
+              message="모든 문항 답변이 준비되었습니다."
               detail="답변을 검토한 뒤 바로 면접 준비로 넘어갈 수 있습니다."
               actions={
                 <Link

--- a/frontend/app/interview/sessions/[sessionId]/page.tsx
+++ b/frontend/app/interview/sessions/[sessionId]/page.tsx
@@ -755,6 +755,7 @@ export default function InterviewSessionPage() {
     stopVoiceCaptureForBoundary({ clearMessages: true });
 
     const moveToResultPage = () => {
+      sessionStatusRef.current = 'completed';
       pendingQuestionFocusRef.current = null;
       router.push(`/interview/sessions/${session.id}/result`);
     };

--- a/frontend/types/application.ts
+++ b/frontend/types/application.ts
@@ -78,3 +78,14 @@ export interface GenerateAnswersRequest {
   useTemplate: boolean;
   regenerate: boolean;
 }
+
+// 자소서 AI 생성 작업 상태
+export type AiGenerationStatus = 'PENDING' | 'IN_PROGRESS' | 'COMPLETED' | 'FAILED';
+
+// POST /applications/{id}/questions/generate-answers 응답 (202 Accepted)
+// GET  /applications/{id}/questions/generate-answers/status 응답
+export interface GenerateAnswersJobResponse {
+  applicationId: number;
+  status: AiGenerationStatus;
+  error: string | null;
+}

--- a/load-test/k6/lib/endpoints.js
+++ b/load-test/k6/lib/endpoints.js
@@ -25,6 +25,7 @@ export const ENDPOINTS = {
   application:            (id) => `${BASE_URL}/api/v1/applications/${id}`,
   applicationQuestions:   (id) => `${BASE_URL}/api/v1/applications/${id}/questions`,
   generateAnswers:        (id) => `${BASE_URL}/api/v1/applications/${id}/questions/generate-answers`,
+  generateAnswersStatus:  (id) => `${BASE_URL}/api/v1/applications/${id}/questions/generate-answers/status`,
 
   // ── CS / 면접 질문 목록 ───────────────────────────────────────────────
   csQuestions: `${BASE_URL}/api/v1/practice/questions`,

--- a/load-test/k6/scenarios/constant-vus.js
+++ b/load-test/k6/scenarios/constant-vus.js
@@ -10,6 +10,10 @@
  *
  * 주의: AI Stub이 활성화된 load-test profile 서버에서만 실행.
  *       Stub 지연: 자소서 ~17s(Gemini), 면접질문 ~8s(Gemini)
+ *
+ * 자소서 AI 생성 흐름 (202 + polling):
+ *   POST generate-answers → 202 Accepted (즉시 반환)
+ *   GET  generate-answers/status 폴링 → COMPLETED/FAILED 확인
  */
 import http from 'k6/http';
 import { sleep } from 'k6';
@@ -20,22 +24,27 @@ import { assertResponse, AI_TIMEOUT } from '../lib/checks.js';
 const VUS      = parseInt(__ENV.VUS || '10');
 const DURATION = __ENV.DURATION || '3m';
 
+// 자소서 폴링 설정
+const POLL_INTERVAL_S   = 2;       // 폴링 간격 (초)
+const POLL_MAX_WAIT_S   = 60;      // 최대 대기 (초) — Stub ~17s 기준 여유 있게
+const POLL_MAX_ATTEMPTS = Math.ceil(POLL_MAX_WAIT_S / POLL_INTERVAL_S);
+
 export const options = {
   vus:      VUS,
   duration: DURATION,
   thresholds: {
-    'http_req_duration{type:read}':         ['p(95)<1000'],
-    'http_req_duration{type:write}':        ['p(95)<2000'],
-    'http_req_duration{type:ai-self-intro}': [`p(95)<${AI_TIMEOUT.selfIntro}`],
-    'http_req_duration{type:ai-interview}':  [`p(95)<${AI_TIMEOUT.interviewQuestions}`],
-    'api_error_rate':                        ['rate<0.05'],
-    'http_req_failed':                       ['rate<0.05'],
+    'http_req_duration{type:read}':      ['p(95)<1000'],
+    'http_req_duration{type:write}':     ['p(95)<2000'],
+    'http_req_duration{type:ai-accept}': ['p(95)<500'],   // 202 즉시 반환 기준
+    'http_req_duration{type:ai-poll}':   ['p(95)<300'],   // 폴링 조회 기준
+    'http_req_duration{type:ai-interview}': [`p(95)<${AI_TIMEOUT.interviewQuestions}`],
+    'api_error_rate':                    ['rate<0.05'],
+    'http_req_failed':                   ['rate<0.05'],
   },
   // url을 systemTags에서 제외 → 동적 ID가 Prometheus 레이블로 올라가지 않아 high cardinality 방지
   systemTags: ['status', 'method', 'name', 'check', 'error', 'error_code', 'scenario'],
-  // AI 호출은 응답이 느리므로 k6 기본 타임아웃(60s) 초과 방지
   http: {
-    timeout: '120s',
+    timeout: '30s',  // 각 요청 타임아웃 (폴링은 짧게, AI 직접 호출 없으므로 30s로 충분)
   },
 };
 
@@ -103,14 +112,58 @@ export default function ({ token, apiKey }) {
     return;
   }
 
-  // ── Step 3: 자소서 AI 생성 (Stub: ~17s) ────────────────────────────────
+  // ── Step 3: 자소서 AI 생성 (202 즉시 반환 + 폴링) ──────────────────────
   const selfIntroRes = http.post(
     ENDPOINTS.generateAnswers(appId),
     JSON.stringify({ useTemplate: true, regenerate: false }),
-    { headers: headers, tags: { type: 'ai-self-intro', name: 'generate_answers' }, timeout: '120s' }
+    { headers: headers, tags: { type: 'ai-accept', name: 'generate_answers_submit' } }
   );
-  if (!assertResponse(selfIntroRes, [200], AI_TIMEOUT.selfIntro)) {
-    console.error(`[VU${__VU}] Step3 자소서생성 실패: ${selfIntroRes.status} ${selfIntroRes.body}`);
+  if (!assertResponse(selfIntroRes, [202], 500)) {
+    console.error(`[VU${__VU}] Step3 자소서생성 제출 실패: ${selfIntroRes.status} ${selfIntroRes.body}`);
+    // 제출 실패해도 면접 질문 생성은 시도
+  } else {
+    // 폴링: COMPLETED 또는 FAILED까지 대기
+    let attempts = 0;
+    let completed = false;
+
+    while (attempts < POLL_MAX_ATTEMPTS) {
+      sleep(POLL_INTERVAL_S);
+      attempts++;
+
+      const pollRes = http.get(
+        ENDPOINTS.generateAnswersStatus(appId),
+        { headers: headers, tags: { type: 'ai-poll', name: 'generate_answers_status' } }
+      );
+
+      if (!assertResponse(pollRes, [200], 300)) {
+        continue; // 일시 오류 → 재시도
+      }
+
+      let jobData = null;
+      try {
+        jobData = JSON.parse(pollRes.body).data;
+      } catch {
+        continue;
+      }
+
+      if (!jobData) continue;
+
+      if (jobData.status === 'COMPLETED') {
+        completed = true;
+        break;
+      }
+
+      if (jobData.status === 'FAILED') {
+        console.error(`[VU${__VU}] Step3 자소서생성 실패(FAILED): ${jobData.error}`);
+        break;
+      }
+
+      // PENDING / IN_PROGRESS → 계속 폴링
+    }
+
+    if (!completed && attempts >= POLL_MAX_ATTEMPTS) {
+      console.warn(`[VU${__VU}] Step3 자소서생성 폴링 타임아웃 (${POLL_MAX_WAIT_S}s 초과)`);
+    }
   }
 
   // ── Step 4: 면접 질문 AI 생성 (Stub: ~8s) ──────────────────────────────
@@ -133,6 +186,5 @@ export default function ({ token, apiKey }) {
     tags: { type: 'write', name: 'delete_application' },
   });
 
-  // AI 호출이 길어서 sleep 최소화
   sleep(0.5);
 }


### PR DESCRIPTION
## 🔗 Issue 번호

- Close #

## 🛠 작업 내역
  Before (동기)                                                                                               
  - POST /{applicationId}/questions/generate-answers → AI 생성 완료까지 블로킹 후 결과 반환 (200 OK)          
                                                                                                              
  After (비동기)                                                                                              
  - POST /{applicationId}/questions/generate-answers → 작업을 큐에 제출하고 즉시 202 Accepted 반환
  - GET /{applicationId}/questions/generate-answers/status → 클라이언트가 폴링해서 상태 확인 (PENDING →
  IN_PROGRESS → COMPLETED/FAILED)

  핵심 변경 포인트:
  - SelfIntroGenerateService.generate() (블로킹) → AsyncSelfIntroGenerateService.submitAsync() (논블로킹)
  - ApplicationAiGenerationJobStore로 작업 상태 인메모리 관리
 - 프론트엔드도 폴링 방식으로 전환


## ✅ 체크리스트

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?