### PR TITLE
feat: repo 분석 결과 영어 출력 전환 - 품질 향상 및 토큰 절약

### DIFF
--- a/backend/src/main/java/com/back/backend/domain/ai/batch/BatchProviderStrategy.java
+++ b/backend/src/main/java/com/back/backend/domain/ai/batch/BatchProviderStrategy.java
@@ -3,12 +3,12 @@ package com.back.backend.domain.ai.batch;
 /**
  * AI Provider별 배치 호출 설정 전략.
  *
- * <p>각 provider의 출력 토큰 한도와 언어 제약이 다르므로,
- * provider에 따라 배치 크기·maxTokens·언어를 캡슐화한다.
+ * <p>각 provider의 출력 토큰 한도가 다르므로,
+ * provider에 따라 배치 크기·maxTokens를 캡슐화한다.
  *
  * <ul>
- *   <li>{@link GeminiFreeStrategy} — Gemini 무료 티어 (8,192 토큰, 영어 강제)</li>
- *   <li>{@link VertexAiStrategy}   — Vertex AI (32,000 토큰, 한국어 허용)</li>
+ *   <li>{@link GeminiFreeStrategy} — Gemini 무료 티어 (8,192 토큰)</li>
+ *   <li>{@link VertexAiStrategy}   — Vertex AI (32,000 토큰)</li>
  * </ul>
  */
 public interface BatchProviderStrategy {
@@ -26,9 +26,4 @@ public interface BatchProviderStrategy {
      */
     int getGlobalBudgetChars();
 
-    /**
-     * true이면 프롬프트에 "Only English" 지시를 추가한다.
-     * Gemini free tier는 영어 출력이 토큰 효율이 2~3배 높다.
-     */
-    boolean isEnglishOnly();
 }

--- a/backend/src/main/java/com/back/backend/domain/ai/batch/GeminiFreeStrategy.java
+++ b/backend/src/main/java/com/back/backend/domain/ai/batch/GeminiFreeStrategy.java
@@ -7,7 +7,7 @@ package com.back.backend.domain.ai.batch;
  *   <li>최대 출력: 8,000 토큰 (Gemini free tier 한도)</li>
  *   <li>최대 repo: 2개</li>
  *   <li>입력 예산: 480,000 chars (2 repos × 240,000 chars/repo ≈ 60K tokens/repo)</li>
- *   <li>언어: 영어 강제 — 한국어 대비 2~3배 토큰 절약</li>
+ *   <li>언어: 영어 강제 — 프롬프트에서 English-only 지시</li>
  * </ul>
  */
 public class GeminiFreeStrategy implements BatchProviderStrategy {
@@ -29,8 +29,4 @@ public class GeminiFreeStrategy implements BatchProviderStrategy {
         return 480_000;
     }
 
-    @Override
-    public boolean isEnglishOnly() {
-        return true;
-    }
 }

--- a/backend/src/main/java/com/back/backend/domain/ai/batch/VertexAiStrategy.java
+++ b/backend/src/main/java/com/back/backend/domain/ai/batch/VertexAiStrategy.java
@@ -7,7 +7,7 @@ package com.back.backend.domain.ai.batch;
  *   <li>최대 출력: 32,000 토큰 (Long Output 모델 활용)</li>
  *   <li>최대 repo: 8개</li>
  *   <li>입력 예산: 800,000 chars (8 repos × 100,000 chars/repo ≈ 25K tokens/repo)</li>
- *   <li>언어: 한국어 허용 — 기본 프롬프트 지시를 그대로 따름</li>
+ *   <li>언어: 영어 강제 — 프롬프트에서 English-only 지시</li>
  * </ul>
  *
  * <p>입력 예산 근거:
@@ -38,8 +38,4 @@ public class VertexAiStrategy implements BatchProviderStrategy {
         return 800_000;
     }
 
-    @Override
-    public boolean isEnglishOnly() {
-        return false;
-    }
 }

--- a/backend/src/main/java/com/back/backend/domain/ai/template/PromptTemplateRegistry.java
+++ b/backend/src/main/java/com/back/backend/domain/ai/template/PromptTemplateRegistry.java
@@ -39,7 +39,7 @@ public class PromptTemplateRegistry {
 
         map.put("ai.portfolio.summary.v1", new PromptTemplate(
             "ai.portfolio.summary.v1", "v1", "portfolio_summary",
-            "system/common-system.txt",
+            "system/portfolio-system.txt",
             "developer/ai.portfolio.summary.v1.txt",
             "schema/portfolio-summary.schema.json",
             0.2, 4000, // 레포지토리 분석 요약이 잘리지 않도록 토큰 여유 확보
@@ -120,7 +120,7 @@ public class PromptTemplateRegistry {
         // allowPartialRecovery: true — JSON 절단 시 완성된 원소만 저장
         map.put("ai.portfolio.summary.batch.v1", new PromptTemplate(
             "ai.portfolio.summary.batch.v1", "v1", "portfolio_summary_batch",
-            "system/common-system.txt",
+            "system/portfolio-system.txt",
             "developer/ai.portfolio.summary.batch.v1.txt",
             null,   // JSON Schema 파일 없음 (배열 검증은 BatchPortfolioSummaryValidator에서 수행)
             0.2, 8000, // 기본값 — executeWithMaxTokens()로 runtime override

--- a/backend/src/main/java/com/back/backend/domain/github/portfolio/BatchRepoSummaryGeneratorService.java
+++ b/backend/src/main/java/com/back/backend/domain/github/portfolio/BatchRepoSummaryGeneratorService.java
@@ -154,8 +154,8 @@ public class BatchRepoSummaryGeneratorService {
         // ── Step 2: provider 전략 결정 (Gemini free vs Vertex AI) ─────────
         BatchProviderStrategy strategy = strategyFactory.resolve(AiProvider.VERTEX_AI);
         int chunkSize = strategy.getMaxReposPerCall();
-        log.info("BatchProviderStrategy resolved: maxReposPerCall={}, maxOutputTokens={}, englishOnly={}",
-                chunkSize, strategy.getMaxOutputTokens(), strategy.isEnglishOnly());
+        log.info("BatchProviderStrategy resolved: maxReposPerCall={}, maxOutputTokens={}",
+                chunkSize, strategy.getMaxOutputTokens());
 
         // ── Step 3~6: 청크별 AI 호출 + 저장 ──────────────────────────────
         List<RepoSummary> allSaved = new ArrayList<>();
@@ -178,7 +178,7 @@ public class BatchRepoSummaryGeneratorService {
             BatchTokenBudget budget = new BatchTokenBudget(
                     strategy.getGlobalBudgetChars(), chunk.size());
 
-            // XML 페이로드 조립 (Gemini free이면 "Only English" 지시 삽입)
+            // XML 페이로드 조립
             String batchPayload = promptBuilder.build(chunk, budget);
             log.info("Chunk {}/{} payload built: chars={}", chunkIdx + 1, chunks.size(), batchPayload.length());
 

--- a/backend/src/main/resources/ai/templates/developer/ai.portfolio.summary.batch.v1.txt
+++ b/backend/src/main/resources/ai/templates/developer/ai.portfolio.summary.batch.v1.txt
@@ -61,12 +61,12 @@ XML <batch_data> 태그 안에 복수의 <repository> 태그가 포함된다.
 stack
   해당 repository의 <code_structure>에서 확인된 기술/프레임워크.
   "어떤 기술을 사용했냐" — 기술명·프레임워크명만.
-  예) Java 17, Spring Boot 3, JPA, Redis, PostgreSQL
+  e.g.) Java 17, Spring Boot 3, JPA, Redis, PostgreSQL
 
 signals
   해당 repository의 <diffs>에서 드러나는 구현·해결 행위 키워드.
   "무엇을 구현/해결했냐" — 기술명이 아닌 행위 중심으로 표현.
-  예) OAuth2 소셜 로그인, 분산 락, GitHub API 연동
+  e.g.) OAuth2 Social Login, Distributed Lock, GitHub API Integration
   stack과 중복 금지.
 
 role
@@ -99,10 +99,10 @@ strengths / risks
 
 각 project JSON 스키마 (필드명을 정확히 사용할 것):
 {
-  "projectKey": "string — 영문 소문자+하이픈",
-  "projectName": "string — 사람이 읽기 좋은 이름",
-  "summary": "string — 2~3문장 요약",
-  "role": "string — 예: 백엔드 개발 / 인증 도메인 담당",
+  "projectKey": "string — lowercase-with-hyphens",
+  "projectName": "string — human-readable project name",
+  "summary": "string — 2-3 sentence summary",
+  "role": "string — e.g. Backend Developer / Auth Domain Lead",
   "stack": ["string"],
   "signals": ["string"],
   "evidenceBullets": [

--- a/backend/src/main/resources/ai/templates/developer/ai.portfolio.summary.v1.txt
+++ b/backend/src/main/resources/ai/templates/developer/ai.portfolio.summary.v1.txt
@@ -33,18 +33,18 @@
 stack
   ## Code Structure의 import 분석과 PageRank 상위 파일에서 확인된 기술/프레임워크.
   "어떤 기술을 사용했냐" — 기술명·프레임워크명만.
-  예) Java 17, Spring Boot 3, JPA, Redis, PostgreSQL
+  e.g.) Java 17, Spring Boot 3, JPA, Redis, PostgreSQL
 
 signals
   ## Contribution Commits에서 드러나는 구현·해결 행위 키워드.
   "무엇을 구현/해결했냐" — 기술명이 아닌 행위 중심으로 표현.
-  예) OAuth2 소셜 로그인, 분산 락, GitHub API 연동, 페이지네이션 최적화
+  e.g.) OAuth2 Social Login, Distributed Lock, GitHub API Integration, Pagination Optimization
   stack과 중복 금지.
 
 role
   ## Code Structure의 기여 파일 패턴 전체를 보고 추론.
   단순 커밋 수 기준이 아닌, 어떤 도메인/레이어를 주로 담당했는지 판단.
-  예) "백엔드 개발 / 인증·포트폴리오 도메인 담당"
+  e.g.) "Backend Developer / Auth & Portfolio Domain Lead"
 
 evidenceBullets
   ## Contribution Commits 중 기능 구현·성능 개선 커밋의 diff에서 추출. 1항목 = 1문장.
@@ -76,36 +76,36 @@ strengths / risks
 출력 JSON 스키마 (필드명을 정확히 사용할 것):
 {
   "project": {
-    "projectKey": "string — 영문 소문자+하이픈, 예: linebot-backend",
-    "projectName": "string — 사람이 읽기 좋은 프로젝트 이름",
-    "summary": "string — 2~3문장 요약",
-    "role": "string — 본인이 맡은 역할, 예: 백엔드 개발 / 인증 도메인 담당",
-    "stack": ["string — 기술/프레임워크명, 예: Java 17, Spring Boot 3"],
-    "signals": ["string — 구현/해결 행위, 예: OAuth2 소셜 로그인, 분산 락"],
+    "projectKey": "string — lowercase-with-hyphens, e.g. linebot-backend",
+    "projectName": "string — human-readable project name",
+    "summary": "string — 2-3 sentence summary",
+    "role": "string — e.g. Backend Developer / Auth Domain Lead",
+    "stack": ["string — technology/framework name, e.g. Java 17, Spring Boot 3"],
+    "signals": ["string — implementation/resolution action, e.g. OAuth2 Social Login, Distributed Lock"],
     "evidenceBullets": [
       {
-        "fact": "string — 구체적 기여 항목 1문장",
-        "challengeRef": "string | null — 파생된 challenge.id, 없으면 null"
+        "fact": "string — specific contribution in one sentence",
+        "challengeRef": "string | null — derived challenge.id, null if none"
       }
     ],
     "challenges": [
       {
-        "id": "string — 짧은 식별자, 예: c1",
-        "what": "string — 어떤 문제/난관이었나",
-        "how": "string — 어떻게 해결했나",
-        "learning": "string — 무엇을 배웠나"
+        "id": "string — short identifier, e.g. c1",
+        "what": "string — what was the problem/difficulty",
+        "how": "string — how was it resolved",
+        "learning": "string — what was learned"
       }
     ],
     "techDecisions": [
       {
-        "decision": "string — 어떤 기술/방식을 선택했나",
-        "reason": "string — 왜 선택했나 (대안 대비 이유)",
-        "tradeOff": "string | null — 트레이드오프, 없으면 null"
+        "decision": "string — what technology/approach was chosen",
+        "reason": "string — why it was chosen (rationale vs alternatives)",
+        "tradeOff": "string | null — trade-off, null if none"
       }
     ],
-    "strengths": ["string — 이 repo에서 드러나는 강점"],
-    "risks": ["string — 약점 또는 개선 필요 항목"],
-    "sourceRefs": ["파일경로 또는 커밋SHA"],
+    "strengths": ["string — strengths evident from this repo"],
+    "risks": ["string — weaknesses or areas for improvement"],
+    "sourceRefs": ["file path or commit SHA"],
     "qualityFlags": ["low_context | weak_evidence"]
   }
 }

--- a/backend/src/main/resources/ai/templates/system/portfolio-system.txt
+++ b/backend/src/main/resources/ai/templates/system/portfolio-system.txt
@@ -1,0 +1,9 @@
+당신은 개발자 취업 준비 플랫폼의 구조화된 AI 엔진이다.
+주어진 입력 범위를 벗어나 사실을 임의로 만들어내지 말라.
+근거가 부족하면 보수적으로 작성하고, 과도한 확신 표현을 피하라.
+반드시 지정된 JSON object 하나만 출력하라.
+마크다운, 설명 문장, 코드 블록, 서론, 후기는 출력하지 말라.
+주어진 enum 후보와 길이 제한을 반드시 지켜라.
+혐오, 차별, 무관한 인성 판단, 민감정보 추정은 금지한다.
+사용자가 제공하지 않은 수치, 회사 정책, 성과, 프로젝트, 기술 스택을 단정하지 말라.
+ALL output text MUST be written in English. Do not use Korean or any other non-English language in any JSON field value. Technical proper nouns (framework names, library names) should use their original English form.

--- a/backend/src/test/java/com/back/backend/domain/ai/template/PromptTemplateRegistryTest.java
+++ b/backend/src/test/java/com/back/backend/domain/ai/template/PromptTemplateRegistryTest.java
@@ -45,7 +45,7 @@ class PromptTemplateRegistryTest {
 
         PromptTemplate template = registry.get("ai.portfolio.summary.v1");
 
-        assertThat(template.systemPromptFile()).isEqualTo("system/common-system.txt");
+        assertThat(template.systemPromptFile()).isEqualTo("system/portfolio-system.txt");
         assertThat(template.developerPromptFile()).isEqualTo("developer/ai.portfolio.summary.v1.txt");
         assertThat(template.schemaFile()).isEqualTo("schema/portfolio-summary.schema.json");
     }


### PR DESCRIPTION
## 🔗 Issue 번호

- Close #379 

## 🛠 작업 내역
GitHub repo 포트폴리오 분석 결과를 한국어 -> 영어로 전환
repo 분석은 중간 데이터로 최종 사용자에게 직접 노출되지 않으므로, 영어 출력이 적합

- 포트폴리오 전용 시스템 프롬프트 분리하여 영어 출력 강제
- 개발자 프롬프트는 한국어 지시문 유지, JSON 스키마 예시만 영어로 전환
- `isEnglishOnly()` 죽은 코드 제거 (로깅에만 사용, 프롬프트 미반영)

### 영어 전환 이유
- LLM 영어 출력 품질이 한국어 대비 높음 (학습 데이터 양 차이)
- 토큰 효율 2~3배 절약 (한국어는 토큰 소비 큼)
- 하위 파이프라인(면접 질문/자소서 생성)은 영어 evidence → 한국어 출력 정상 동작

### 하위 소비자 호환성
- 면접 질문 생성: 영어 evidence 입력 → 한국어 질문 출력 (프롬프트에 한국어 지시 있음)
- 자소서 생성: 동일하게 호환
- MergedSummaryService: JSON 필드명 기반 집계, 값 언어 무관

## ✅ 체크리스트

- [ ]  Merge 대상 branch가 올바른가?
- [ ]  약속된 컨벤션 을 준수하는가?
- [ ]  PR과 관련없는 변경사항이 없는가?
- [ ]  Test가 완료되었는가?